### PR TITLE
Refactor SlyCooper classes and enums structure

### DIFF
--- a/modules/Sly Cooper and the Thievius Raccoonus/SlyCooper_classes.h
+++ b/modules/Sly Cooper and the Thievius Raccoonus/SlyCooper_classes.h
@@ -3,7 +3,7 @@
 
 /**
  * Name: PlayStation2 - PCSX2 :: Sly Cooper and the Thievous Racoonus
- * Version: 0.0.1
+ * Version: 0.0.2
  * Author: NightFyre
 
 RESOURCES & CREDITS: Sly Cooper Modding Server
@@ -17,103 +17,138 @@ namespace PlayStation2
 {
 	namespace SlyCooper 
 	{
-		class Offsets
+		namespace Classes
 		{
-		public:
-			std::string _data;
-
-			//	Pointers
-			int o_GS		= 0x2623C0;			//	GameState
-			int o_WS		= 0x2623C4;			//  WorldState
-			int o_LS		= 0x2623C8;			//  LevelState
-			int o_JT		= 0x262E10;			//  SlyPointer
-			int o_CC		= 0x126A64;			//	CustomColors
-			int o_EOC		= 0x2623E0;			//	EntityOutlineColor
-
-			std::vector<int> OffsetArray = 
+			class JT
 			{
-				o_GS,		
-				o_WS,       
-				o_LS,       
-				o_JT,       
-				o_CC,		
-				o_EOC,		
-			};
+			public:
+				char pad_0000[20]; //0x0000
+				int32_t pSW; //0x0014
+				char pad_0018[232]; //0x0018
+				Vec3 Origin; //0x0100
+				char pad_010C[68]; //0x010C
+				Vec3 Velocity; //0x0150
+				char pad_015C[500]; //0x015C
+				Vec3 Gravity; //0x0350
+				char pad_035C[732]; //0x035C
+				float mFacingAngle; //0x0638
+				char pad_063C[108]; //0x063C
+				float mJumpHeight; //0x06A8
+				char pad_06AC[20]; //0x06AC
+				int32_t pCollisionSource; //0x06C0
+				char pad_06C4[7004]; //0x06C4
+				Enums::JT_STATES_INDEX eState; //0x2220
+				char pad_2224[4]; //0x2224
+				Enums::JT_BODY_STATES_INDEX eBodyState; //0x2228
+				char pad_222C[16]; //0x222C
+				Enums::JT_CANE_STATES_INDEX eCaneState; //0x223C
+				char pad_2240[40]; //0x2240
+				int32_t mMomentumHalting; //0x2268
+				char pad_226C[44]; //0x226C
+				int32_t mJumpAddr; //0x2298
+				char pad_229C[1052]; //0x229C
+				int32_t mZAPComponent; //0x26B8
+				char pad_26BC[104]; //0x26BC
+				float mOpacity; //0x2724
+				char pad_2728[31760]; //0x2728
+				int8_t aBodyOutline[4]; //0xA338
+				char pad_A33C[335468]; //0xA33C
+				int8_t aCaneHandleOutline[4]; //0x5C1A8
+				char pad_5C1AC[3420]; //0x5C1AC
+				int8_t aCaneHookOutline[4]; //0x5CF08
+				char pad_5CF0C[192076]; //0x5CF0C
+				int8_t aLeftHandOutline[4]; //0x8BD58
+				char pad_8BD5C[230044]; //0x8BD5C
+				int8_t aHeadOutline[4]; //0xC3FF8
+				char pad_C3FFC[23868]; //0xC3FFC
+				int8_t aEarsOutline[4]; //0xC9D38
+				char pad_C9D3C[23212]; //0xC9D3C
+				int8_t aHatOutline[4]; //0xCF7E8
+				char pad_CF7EC[38844]; //0xCF7EC
+				int8_t aBackpackOutline[4]; //0xD8FA8
 
-			std::vector<std::string> names = 
+			}; //Size: 0xD8FAC
+
+			class CM
 			{
-				"GameState",
-				"WorldState",
-				"LevelState",
-				"SlyPointer",
-				"CustomColorAddr",
-				"EntityOutlineColorAddr"
-			};
+			public:
+				char pad_0000[64]; //0x0000
+				Vec3 mOrigin; //0x0040
+				char pad_004C[100]; //0x004C
+				float mObjectFadeDistance; //0x00B0
+				char pad_00B4[48]; //0x00B4
+				float mYawTilt; //0x00E4
+				char pad_00E8[4]; //0x00E8
+				float mPitchTilt; //0x00EC
+				float mHorizontalOffset; //0x00F0
+				float mVerticalOffset; //0x00F4
+				float mRenderDistance; //0x00F8
+				float mZoomLevel; //0x00FC
+				char pad_0100[196]; //0x0100
+				float mFOV; //0x01C4
+				float mTargetFOV; //0x01C8
+				char pad_01CC[44]; //0x01CC
+				float mFogThreshold; //0x01F8
+				char pad_01FC[4]; //0x01FC
+				float mFogAmount; //0x0200
+				int8_t aFogColor[4]; //0x0204
+				char pad_0208[24]; //0x0208
+				int32_t mResetCameraFlag; //0x0220
+				char pad_0224[440]; //0x0224
+				uint32_t pFocusEntity; //0x03DC
+				char pad_03E0[328]; //0x03E0
+				int32_t mCameraAngle; //0x0528
+				float mYawAngleRadians; //0x052C
+			}; //Size: 0x0530
+			static_assert(sizeof(CM) == 0x530);
 
-			// Auto Resolve List
-		public:
-			uintptr_t slyPointer			= g_PS2Mem->GetClassPtr(o_JT);
-			uintptr_t gsPointer				= g_PS2Mem->GetClassPtr(o_GS);
-			uintptr_t wsPointer				= g_PS2Mem->GetClassPtr(o_WS);
-			uintptr_t lsPointer				= g_PS2Mem->GetClassPtr(o_LS);
-			uintptr_t CustomColors			= g_PS2Mem->GetAddr(o_CC);
-			uintptr_t EntityOutlineColors	= g_PS2Mem->GetAddr(o_EOC);
+			class LS
+			{
+			public:
+				Enums::FLS eLevelState; //0x0000
+				float mPlayTimer; //0x0004
+				char pad_0008[4]; //0x0008
+				float mDifficulty; //0x000C
+				char pad_0010[84]; //0x0010
+				int32_t mBottlesCount; //0x0064
+				uint32_t mBottleBitfield; //0x0068
+				char pad_006C[12]; //0x006C
+			}; //Size: 0x0078
+			static_assert(sizeof(LS) == 0x78);
 
+			class WS
+			{
+			public:
+				class LS aLevelStates[9]; //0x0000
+				int32_t mKeysCount; //0x0438
+				int32_t mVaultsCount; //0x043C
+				int32_t mMTSCount; //0x0440
+				float mWorldPlayTimer; //0x0444
+				Enums::FWS eWorldState; //0x0448
+			}; //Size: 0x044C
+			static_assert(sizeof(WS) == 0x44C);
 
-			//	Functions
-		public:
-			std::string LogData();
-		};
-
-		class JT
-		{
-
-			//	NATIVE OFFSETS
-		public:
-			//int objectBase;			//0x0000
-			//char pad_0004[16];		//0x0004
-			//__int64 SWPointer;		//0x0014
-			//char pad_001C[228];		//0x001C
-			char			pad_0000[256];			//0x0000
-			Vector3			Position;				//0x0100
-			char			pad_010C[68];			//0x010C
-			Vector3			Velocity;				//0x0150
-			char			pad_015C[508];			//0x015C
-			float			Gravity;				//0x0358
-			char			pad_035C[732];			//0x035C
-			float			FacingAngle;			//0x0638
-			char			pad_063C[108];			//0x063C
-			float			JumpHeight;				//0x06A8
-			char			pad_06AC[7028];			//0x06AC
-			JTStates		JTState;				//0x2220
-			JTBodyStates	JTBodyState;			//0x2224
-			JTCaneStates	JTCaneState;			//0x2228
-			char			pad_222C[60];			//0x222C
-			int				MomentumHalting;		//0x2268
-			char			pad_226C[556];			//0x226C
-			int				JumpAddress2;			//0x2498
-			char			pad_249C[367884];		//0x249C
-			BYTE			CaneHandleOutline[4];	//0x5C1A8
-			char			pad_5C1AC[3420];		//0x5C1AC
-			BYTE			CaneHookHandle[4];		//0x5CF08
-			char			pad_5CF0C[192076];		//0x5CF0C
-			BYTE			LeftHandOutlineA[4];	//0x8BD58
-			char			pad_8BD5C[230044];		//0x8BD5C
-			BYTE			HeadOutline[4];			//0xC3FF8
-			char			pad_C3FFC[23868];		//0xC3FFC
-			BYTE			EarsOutline[4];			//0xC9D38
-			char			pad_C9D3C[23212];		//0xC9D3C
-			BYTE			HatOutline[4];			//0xCF7E8
-			char			pad_CF7EC[38844];		//0xCF7EC
-			BYTE			BackpackOutline[4];		//0xD8FA8
-
-			//	FUNCTIONS
-		public:
-			bool			IsValid();
-			void			SyncOutlines(float value);
-			void			RestoreOutlines();
-		};
-		//Size: 0xD8FAC
+			class GS
+			{
+			public:
+				Enums::FGS eGameState; //0x0000
+				int32_t nChecksum; //0x0004
+				char pad_0008[4]; //0x0008
+				float mTotalPlayTime; //0x000C
+				class WS WorldSaves[6]; //0x0010
+				int32_t mCurrentWorldID; //0x19D8
+				int32_t mCurrentLevelID; //0x19DC
+				int32_t mLivesCount; //0x19E0
+				int32_t mCharmsCount; //0x19E4
+				int32_t mCoinsCount; //0x19E8
+				uint32_t btSettings; //0x19EC
+				int32_t mUnlockedThiefMoves; //0x19F0
+				int32_t mUnlockedMovies; //0x19F4
+				int32_t mGameCompletionFlags; //0x19F8
+				int32_t mLastThiefMove; //0x19FC
+			}; //Size: 0x1A00
+			static_assert(sizeof(GS) == 0x1A00);
+		}
 	}
 }
 #pragma pack(pop)

--- a/modules/Sly Cooper and the Thievius Raccoonus/SlyCooper_package.cpp
+++ b/modules/Sly Cooper and the Thievius Raccoonus/SlyCooper_package.cpp
@@ -1,5 +1,5 @@
 #pragma once
-#include "../../pch.h"
+#include "SlyCooper_Package.h"
 
 /**
  * Name: PlayStation2 - PCSX2 :: Sly Cooper and the Thievous Racoonus
@@ -17,316 +17,296 @@ namespace PlayStation2
 {
 	namespace SlyCooper
 	{
-		//----------------------------------------------------------------------------------------------------
-		//										OFFSETS
-		// - Offsets
-		//-----------------------------------------------------------------------------------
-
-		///---------------------------------------------------------------------------------------------------
-		//	[OFFSETS]
-		//	OUTPUT
-		// 0x00000000	0x00000000	:	<OffsetName>		// display like native PS2 Memory
-		//NOTE: Ends with 2New Line
-		std::string Offsets::LogData()
-		{
-			char data[0x1024];
-			const char* data2 = "%llX	0x%08X	:	%s\n";
-			std::string _data;
-			for (int i = 0; i < OffsetArray.size(); i++) {
-				sprintf_s(data, data2, g_PS2Mem->GetAddr(OffsetArray[i]), g_PS2Mem->PS2Read<int>(g_PS2Mem->GetAddr(OffsetArray[i])), names[i].c_str());
-				_data += data;
-			}
-			return (_data += "\n");
-		}
 
 		//----------------------------------------------------------------------------------------------------
 		//										JT
 		// - Jt
 		//-----------------------------------------------------------------------------------
 
-		///---------------------------------------------------------------------------------------------------
-		//	[JT]
-		/// Returns Class Pointer Status
-		bool JT::IsValid()
-		{
-			return ((unsigned int)this->pad_0000 == 0x000000) ? FALSE : TRUE;
-		}
-
-		///---------------------------------------------------------------------------------------------------
-		//	[JT]
-		void JT::SyncOutlines(float value)
-		{
-			Offsets offsets;
-			auto address = offsets.CustomColors;
-			if (g_PS2Mem->PS2Read<int>(address) != NULL)
-				g_PS2Mem->PS2Write<int>(address, NULL);
-
-			//	Change all Slys outline colors
-			//this->CaneHandleOutline		= value;
-			//this->CaneHookHandle			= value;	
-			//this->LeftHandOutlineA		= value;
-			//this->HeadOutline				= value;
-			//this->HatOutline				= value;
-			//this->BackpackOutline			= value;
-		}
-
-		///---------------------------------------------------------------------------------------------------
-		//	[JT]
-		void JT::RestoreOutlines()
-		{
-			Offsets offsets;
-			auto address = offsets.CustomColors;
-			if (g_PS2Mem->PS2Read<int>(address) == NULL)
-				g_PS2Mem->PS2Write<int>(address, 0xAC910268);
-		}
 	}
 }
 
-	//	DEBUG MENU
-	/*
-		static const ImVec4 defaultColor = ImVec4(16.0f / 255.0f, 16.0f / 255.0f, 16.0f / 255.0f, 128.0f / 255.0f);					//	[ 0x10, 0x10, 0x10, 0x80 ]
+//	///---------------------------------------------------------------------------------------------------
+//	//	[JT]
+//	/// Returns Class Pointer Status
+//	bool JT::IsValid()
+//	{
+//		return ((unsigned int)this->pad_0000 == 0x000000) ? FALSE : TRUE;
+//	}
+//	
+//	///---------------------------------------------------------------------------------------------------
+//	//	[JT]
+//	void JT::SyncOutlines(float value)
+//	{
+//		Offsets offsets;
+//		auto address = offsets.CustomColors;
+//		if (g_PS2Mem->PS2Read<int>(address) != NULL)
+//			g_PS2Mem->PS2Write<int>(address, NULL);
+//	
+//		//	Change all Slys outline colors
+//		//this->CaneHandleOutline		= value;
+//		//this->CaneHookHandle			= value;	
+//		//this->LeftHandOutlineA		= value;
+//		//this->HeadOutline				= value;
+//		//this->HatOutline				= value;
+//		//this->BackpackOutline			= value;
+//	}
+//	
+//	///---------------------------------------------------------------------------------------------------
+//	//	[JT]
+//	void JT::RestoreOutlines()
+//	{
+//		Offsets offsets;
+//		auto address = offsets.CustomColors;
+//		if (g_PS2Mem->PS2Read<int>(address) == NULL)
+//			g_PS2Mem->PS2Write<int>(address, 0xAC910268);
+//	}
+// 
+//	DEBUG MENU
+/*
+	static const ImVec4 defaultColor = ImVec4(16.0f / 255.0f, 16.0f / 255.0f, 16.0f / 255.0f, 128.0f / 255.0f);					//	[ 0x10, 0x10, 0x10, 0x80 ]
 
-		static bool bGeneralOutline = FALSE;
-		static bool bRGB_SLY = FALSE;
-		static ImVec4 main_color_picker = ImVec4(16.0f / 255.0f, 16.0f / 255.0f, 16.0f / 255.0f, 128.0f / 255.0f);				//	[ 0x10, 0x10, 0x10, 0x80 ]
+	static bool bGeneralOutline = FALSE;
+	static bool bRGB_SLY = FALSE;
+	static ImVec4 main_color_picker = ImVec4(16.0f / 255.0f, 16.0f / 255.0f, 16.0f / 255.0f, 128.0f / 255.0f);				//	[ 0x10, 0x10, 0x10, 0x80 ]
 
-		static bool bCaneHandle_outline = FALSE;
-		static ImVec4 CaneHandle_picker = ImVec4(16.0f / 255.0f, 16.0f / 255.0f, 16.0f / 255.0f, 128.0f / 255.0f);				//	[ 0x10, 0x10, 0x10, 0x80 ]
+	static bool bCaneHandle_outline = FALSE;
+	static ImVec4 CaneHandle_picker = ImVec4(16.0f / 255.0f, 16.0f / 255.0f, 16.0f / 255.0f, 128.0f / 255.0f);				//	[ 0x10, 0x10, 0x10, 0x80 ]
 
-		static bool bCaneHookHandle_outline = FALSE;
-		static ImVec4 CaneHookHandle_picker = ImVec4(16.0f / 255.0f, 16.0f / 255.0f, 16.0f / 255.0f, 128.0f / 255.0f);			//	[ 0x10, 0x10, 0x10, 0x80 ]
+	static bool bCaneHookHandle_outline = FALSE;
+	static ImVec4 CaneHookHandle_picker = ImVec4(16.0f / 255.0f, 16.0f / 255.0f, 16.0f / 255.0f, 128.0f / 255.0f);			//	[ 0x10, 0x10, 0x10, 0x80 ]
 
-		static bool bLeftHandOutline_outline = FALSE;
-		static ImVec4 LeftHandOutline_picker = ImVec4(0.0f / 255.0f, 255.0f / 255.0f, 255.0f / 255.0f, 0.0f / 255.0f);			//	[ 0x00, 0xFF, 0xFF, 0x00 ]
+	static bool bLeftHandOutline_outline = FALSE;
+	static ImVec4 LeftHandOutline_picker = ImVec4(0.0f / 255.0f, 255.0f / 255.0f, 255.0f / 255.0f, 0.0f / 255.0f);			//	[ 0x00, 0xFF, 0xFF, 0x00 ]
 
-		static bool bHeadOutline_outline = FALSE;
-		static ImVec4 HeadOutline_picker = ImVec4(46.0f / 255.0f, 144.0f / 255.0f, 96.0f / 255.0f, 62.0f / 255.0f);				//	[ 0x2E, 0x90, 0x60, 0x3E ]
+	static bool bHeadOutline_outline = FALSE;
+	static ImVec4 HeadOutline_picker = ImVec4(46.0f / 255.0f, 144.0f / 255.0f, 96.0f / 255.0f, 62.0f / 255.0f);				//	[ 0x2E, 0x90, 0x60, 0x3E ]
 
-		static bool bEarsOutline_outline = FALSE;
-		static ImVec4 EarsOutline_picker = ImVec4(16.0f / 255.0f, 16.0f / 255.0f, 16.0f / 255.0f, 128.0f / 255.0f);				//	[ 0xDD, 0x24, 0x06, 0x3F ]
+	static bool bEarsOutline_outline = FALSE;
+	static ImVec4 EarsOutline_picker = ImVec4(16.0f / 255.0f, 16.0f / 255.0f, 16.0f / 255.0f, 128.0f / 255.0f);				//	[ 0xDD, 0x24, 0x06, 0x3F ]
 
-		static bool bHatOutline_outline = FALSE;
-		static ImVec4 HatOutline_picker = ImVec4(16.0f / 255.0f, 16.0f / 255.0f, 16.0f / 255.0f, 128.0f / 255.0f);				//	[ 0x01, 0x00, 0x00, 0x00 ]
+	static bool bHatOutline_outline = FALSE;
+	static ImVec4 HatOutline_picker = ImVec4(16.0f / 255.0f, 16.0f / 255.0f, 16.0f / 255.0f, 128.0f / 255.0f);				//	[ 0x01, 0x00, 0x00, 0x00 ]
 
-		static bool bBackpackOutline_outline = FALSE;
-		static ImVec4 BackpackOutline_picker = ImVec4(16.0f / 255.0f, 16.0f / 255.0f, 16.0f / 255.0f, 128.0f / 255.0f);			//	[ 0x00, 0x00, 0x7A, 0x44 ]
+	static bool bBackpackOutline_outline = FALSE;
+	static ImVec4 BackpackOutline_picker = ImVec4(16.0f / 255.0f, 16.0f / 255.0f, 16.0f / 255.0f, 128.0f / 255.0f);			//	[ 0x00, 0x00, 0x7A, 0x44 ]
 
 
-		void ChangeBaseOutlineColor(uintptr_t address, ImVec4 Color)
-		{
-			float floats[4] = { (Color.x * 255), (Color.y * 255), (Color.z * 255), (Color.w * 255) };
+	void ChangeBaseOutlineColor(uintptr_t address, ImVec4 Color)
+	{
+		float floats[4] = { (Color.x * 255), (Color.y * 255), (Color.z * 255), (Color.w * 255) };
 
-			Offsets offsets;
-			auto permCheckAddr = offsets.CustomColors;
-			if (g_Engine->PS2Read<int>(permCheckAddr) == NULL)
-				g_Engine->PS2Write<int>(permCheckAddr, 0xAC910268);
+		Offsets offsets;
+		auto permCheckAddr = offsets.CustomColors;
+		if (g_Engine->PS2Read<int>(permCheckAddr) == NULL)
+			g_Engine->PS2Write<int>(permCheckAddr, 0xAC910268);
 
-			for (int i = 0; i < 4; i++) {
-				g_Engine->PS2Write<int8_t>(address, floats[i]);
-				address++;
-			}
+		for (int i = 0; i < 4; i++) {
+			g_Engine->PS2Write<int8_t>(address, floats[i]);
+			address++;
+		}
+	}
+
+	void ChangeOutlineColorEx(ImVec4 Color)
+	{
+		// Convert ImVec4
+		float test[4] = { (Color.x * 255), (Color.y * 255), (Color.z * 255), (Color.w * 255) };
+
+		Offsets offsets;
+		auto address = offsets.CustomColors;
+		g_Engine->PS2Write<int>(address, NULL);
+
+		auto colorAddress = offsets.EntityOutlineColors;
+		for (int i = 0; i < 4; i++) {
+			g_Engine->PS2Write<int8_t>(colorAddress, test[i]);
+			colorAddress++;
 		}
 
-		void ChangeOutlineColorEx(ImVec4 Color)
-		{
-			// Convert ImVec4
-			float test[4] = { (Color.x * 255), (Color.y * 255), (Color.z * 255), (Color.w * 255) };
+		//g_Engine->PS2Write<int>(address, 0xAC910268);
+	}
 
-			Offsets offsets;
-			auto address = offsets.CustomColors;
-			g_Engine->PS2Write<int>(address, NULL);
+	void RGBSLY()
+	{
+		Offsets offsets;
+		auto permCheckAddr = offsets.CustomColors;
+		if (g_Engine->PS2Read<int>(permCheckAddr) == NULL)
+			g_Engine->PS2Write<int>(permCheckAddr, 0xAC910268);
 
-			auto colorAddress = offsets.EntityOutlineColors;
-			for (int i = 0; i < 4; i++) {
-				g_Engine->PS2Write<int8_t>(colorAddress, test[i]);
-				colorAddress++;
-			}
-
-			//g_Engine->PS2Write<int>(address, 0xAC910268);
+		// Convert ImVec4
+		float test[4] = { (g_Menu->dbg_RAINBOW.Value.x * 255), (g_Menu->dbg_RAINBOW.Value.y * 255), (g_Menu->dbg_RAINBOW.Value.z * 255), (g_Menu->dbg_RAINBOW.Value.w * 255) };
+		auto colorAddress = offsets.EntityOutlineColors;
+		for (int i = 0; i < 4; i++) {
+			g_Engine->PS2Write<int8_t>(colorAddress, test[i]);
+			colorAddress++;
 		}
-
-		void RGBSLY()
-		{
-			Offsets offsets;
-			auto permCheckAddr = offsets.CustomColors;
-			if (g_Engine->PS2Read<int>(permCheckAddr) == NULL)
-				g_Engine->PS2Write<int>(permCheckAddr, 0xAC910268);
-
-			// Convert ImVec4
-			float test[4] = { (g_Menu->dbg_RAINBOW.Value.x * 255), (g_Menu->dbg_RAINBOW.Value.y * 255), (g_Menu->dbg_RAINBOW.Value.z * 255), (g_Menu->dbg_RAINBOW.Value.w * 255) };
-			auto colorAddress = offsets.EntityOutlineColors;
-			for (int i = 0; i < 4; i++) {
-				g_Engine->PS2Write<int8_t>(colorAddress, test[i]);
-				colorAddress++;
-			}
-		}
-		*/
-		
-	/*
-
-		///
-		Sly1::Offsets offsets;
-		Sly1::JT* PLAYER = (Sly1::JT*)offsets.slyPointer;
-
-		ImGui::TextCentered("[ SLY COLOR OUTLINES ]", TRUE, ImColor(0, 255, 255, 200));
-		ImGui::Spacing();
-		ImGui::Separator();
-
-		{
-
-			ImGui::Toggle(" General ", &bGeneralOutline);
-			ImGui::SameLine();
-			window->DC.CursorPos.x = (window->DC.CursorPos.x + 20);
-			ToolLocation.x = window->DC.CursorPos.x;
-			ImGui::ColorEdit4("##gdskhjaoergea", (float*)&main_color_picker, ImGuiColorEditFlags_AlphaBar | ImGuiColorEditFlags_AlphaPreviewHalf | ImGuiColorEditFlags_NoInputs);
-			if (bGeneralOutline)															//
-				ChangeBaseOutlineColor(offsets.EntityOutlineColors, main_color_picker);			//
-			ImGui::SameLine();																//
-			if (ImGui::Button("RESET##0"))	//
-			{
-				bGeneralOutline = FALSE;
-				main_color_picker = defaultColor;
-				ChangeBaseOutlineColor(offsets.EntityOutlineColors, defaultColor);				//
-			}
-
-			//---------------------------------------------------------------------------------------------------
-
-			ImGui::Toggle(" Cane ", &bCaneHandle_outline);
-			ImGui::SameLine();
-			window->DC.CursorPos.x = ToolLocation.x;
-			ImGui::ColorEdit4("##ajartyarasrgfhsr", (float*)&CaneHandle_picker, ImGuiColorEditFlags_AlphaBar | ImGuiColorEditFlags_AlphaPreviewHalf | ImGuiColorEditFlags_NoInputs);
-			if (bCaneHandle_outline) {
-				float cane_color[4] = { (CaneHandle_picker.x * 255), (CaneHandle_picker.y * 255), (CaneHandle_picker.z * 255), (CaneHandle_picker.w * 255) };
-				g_Engine->PS2Write<int>(offsets.CustomColors, NULL);
-				for (int i = 0; i < 4; i++) {
-					PLAYER->CaneHandleOutline[i] = cane_color[i];
-					PLAYER->CaneHookHandle[i] = cane_color[i];
-				}
-			}
-			ImGui::SameLine();
-			if (ImGui::Button("RESET##1"))
-			{
-				bCaneHandle_outline = FALSE;
-				CaneHandle_picker = defaultColor;
-				g_Engine->PS2Write<int>(offsets.CustomColors, 0xAC910268);
-
-			}
-
-			//---------------------------------------------------------------------------------------------------
-
-			
-			ImGui::Toggle("CaneHook");
-			window->DC.CursorPos.x = ToolLocation.x;
-			ImGui::SameLine();
-			ImGui::ColorEdit4("##adfharjhrthbsh", (float*)&CaneHandle_picker, ImGuiColorEditFlags_AlphaBar | ImGuiColorEditFlags_AlphaPreviewHalf | ImGuiColorEditFlags_NoInputs);
-			ImGui::SameLine();
-			if (ImGui::Button("RESET##2", ImVec2(ImGui::GetContentRegionAvail().x, NULL)))
-			{
-
-			}
-
-			//---------------------------------------------------------------------------------------------------
-
-			ImGui::Toggle("LeftHand");
-			window->DC.CursorPos.x = ToolLocation.x;
-			ImGui::SameLine();
-			ImGui::ColorEdit4("##advbarthhbthbtr", (float*)&CaneHandle_picker, ImGuiColorEditFlags_AlphaBar | ImGuiColorEditFlags_AlphaPreviewHalf | ImGuiColorEditFlags_NoInputs);
-			ImGui::SameLine();
-			if (ImGui::Button("RESET##3", ImVec2(ImGui::GetContentRegionAvail().x, NULL)))
-			{
-
-			}
-
-			//---------------------------------------------------------------------------------------------------
-
-			ImGui::Toggle("HeadOutline");
-			window->DC.CursorPos.x = ToolLocation.x;
-			ImGui::SameLine();
-			ImGui::ColorEdit4("##zdfbnhzadfdgaehtsarn", (float*)&CaneHandle_picker, ImGuiColorEditFlags_AlphaBar | ImGuiColorEditFlags_AlphaPreviewHalf | ImGuiColorEditFlags_NoInputs);
-			ImGui::SameLine();
-			if (ImGui::Button("RESET##4", ImVec2(ImGui::GetContentRegionAvail().x, NULL)))
-			{
-
-			}
-
-			//---------------------------------------------------------------------------------------------------
-
-			ImGui::Toggle("Ears");
-			window->DC.CursorPos.x = ToolLocation.x;
-			ImGui::SameLine();
-			ImGui::ColorEdit4("##dzsfnaarthnsmst", (float*)&CaneHandle_picker, ImGuiColorEditFlags_AlphaBar | ImGuiColorEditFlags_AlphaPreviewHalf | ImGuiColorEditFlags_NoInputs);
-			ImGui::SameLine();
-			if (ImGui::Button("RESET##5", ImVec2(ImGui::GetContentRegionAvail().x, NULL)))
-			{
-
-			}
-
-			//---------------------------------------------------------------------------------------------------
-
-			ImGui::Toggle("Hat");
-			window->DC.CursorPos.x = ToolLocation.x;
-			ImGui::SameLine();
-			ImGui::ColorEdit4("##dvfbanrthsrtym", (float*)&CaneHandle_picker, ImGuiColorEditFlags_AlphaBar | ImGuiColorEditFlags_AlphaPreviewHalf | ImGuiColorEditFlags_NoInputs);
-			ImGui::SameLine();
-			if (ImGui::Button("RESET##6", ImVec2(ImGui::GetContentRegionAvail().x, NULL)))
-			{
-
-			}
-
-			//---------------------------------------------------------------------------------------------------
-
-			ImGui::Toggle("Backpack");
-			window->DC.CursorPos.x = ToolLocation.x;
-			ImGui::SameLine();
-			ImGui::ColorEdit4("##zdngbtrazbgdzshrt", (float*)&CaneHandle_picker, ImGuiColorEditFlags_AlphaBar | ImGuiColorEditFlags_AlphaPreviewHalf | ImGuiColorEditFlags_NoInputs);
-			ImGui::SameLine();
-			if (ImGui::Button("RESET##7", ImVec2(ImGui::GetContentRegionAvail().x, NULL)))
-			{
-
-			}
-
-			//---------------------------------------------------------------------------------------------------
-
-		}
-
-		if (ImGui::Toggle(" RGB SLY ", &bRGB_SLY))
-		{
-			// on deactivate restore sky outline to normal
-			if (!bRGB_SLY)
-				ChangeBaseOutlineColor(offsets.EntityOutlineColors, defaultColor);
-		}
-
-		ImGui::Spacing();
-		ImGui::Separator();
-		ImGui::Spacing();
-
-		if (ImGui::Button("Test Read Memory", ImVec2(ImGui::GetWindowContentRegionWidth(), 20)))
-		{
-			auto address = offsets.CustomColors;
-
-			auto value = g_Engine->PS2Read<int>(address);
-
-			g_Console->printdbg("Test Read Memory Address: %llX\nVALUE: [%08X]\n\n", Console::Colors::blue, address, value);
-		}
-
-		if (ImGui::Button("Test Write Memory", ImVec2(ImGui::GetWindowContentRegionWidth(), 20)))
-		{
-
-			auto address = offsets.CustomColors;
-
-			unsigned int value = g_Engine->PS2Read<int>(address);
-
-			if (value != NULL)
-				g_Engine->PS2Write<int>(address, NULL);
-			else
-				g_Engine->PS2Write<int>(address, 0xAC910268);
-
-			g_Console->printdbg("Test Write Memory: %llX\nVALUE: [%08X]\n\n", Console::Colors::blue, address, g_Engine->PS2Read<int>(address));
-
-		}
-
-		if (ImGui::Button("Display Offsets Data", ImVec2(ImGui::GetWindowContentRegionWidth(), 20)))
-			g_Console->printdbg("[+] LOG::OffsetData\n%s", Console::Colors::DEFAULT, offsets.LogData().c_str());
-	
-	
+	}
 	*/
+	
+/*
+
+	///
+	Sly1::Offsets offsets;
+	Sly1::JT* PLAYER = (Sly1::JT*)offsets.slyPointer;
+
+	ImGui::TextCentered("[ SLY COLOR OUTLINES ]", TRUE, ImColor(0, 255, 255, 200));
+	ImGui::Spacing();
+	ImGui::Separator();
+
+	{
+
+		ImGui::Toggle(" General ", &bGeneralOutline);
+		ImGui::SameLine();
+		window->DC.CursorPos.x = (window->DC.CursorPos.x + 20);
+		ToolLocation.x = window->DC.CursorPos.x;
+		ImGui::ColorEdit4("##gdskhjaoergea", (float*)&main_color_picker, ImGuiColorEditFlags_AlphaBar | ImGuiColorEditFlags_AlphaPreviewHalf | ImGuiColorEditFlags_NoInputs);
+		if (bGeneralOutline)															//
+			ChangeBaseOutlineColor(offsets.EntityOutlineColors, main_color_picker);			//
+		ImGui::SameLine();																//
+		if (ImGui::Button("RESET##0"))	//
+		{
+			bGeneralOutline = FALSE;
+			main_color_picker = defaultColor;
+			ChangeBaseOutlineColor(offsets.EntityOutlineColors, defaultColor);				//
+		}
+
+		//---------------------------------------------------------------------------------------------------
+
+		ImGui::Toggle(" Cane ", &bCaneHandle_outline);
+		ImGui::SameLine();
+		window->DC.CursorPos.x = ToolLocation.x;
+		ImGui::ColorEdit4("##ajartyarasrgfhsr", (float*)&CaneHandle_picker, ImGuiColorEditFlags_AlphaBar | ImGuiColorEditFlags_AlphaPreviewHalf | ImGuiColorEditFlags_NoInputs);
+		if (bCaneHandle_outline) {
+			float cane_color[4] = { (CaneHandle_picker.x * 255), (CaneHandle_picker.y * 255), (CaneHandle_picker.z * 255), (CaneHandle_picker.w * 255) };
+			g_Engine->PS2Write<int>(offsets.CustomColors, NULL);
+			for (int i = 0; i < 4; i++) {
+				PLAYER->CaneHandleOutline[i] = cane_color[i];
+				PLAYER->CaneHookHandle[i] = cane_color[i];
+			}
+		}
+		ImGui::SameLine();
+		if (ImGui::Button("RESET##1"))
+		{
+			bCaneHandle_outline = FALSE;
+			CaneHandle_picker = defaultColor;
+			g_Engine->PS2Write<int>(offsets.CustomColors, 0xAC910268);
+
+		}
+
+		//---------------------------------------------------------------------------------------------------
+
+		
+		ImGui::Toggle("CaneHook");
+		window->DC.CursorPos.x = ToolLocation.x;
+		ImGui::SameLine();
+		ImGui::ColorEdit4("##adfharjhrthbsh", (float*)&CaneHandle_picker, ImGuiColorEditFlags_AlphaBar | ImGuiColorEditFlags_AlphaPreviewHalf | ImGuiColorEditFlags_NoInputs);
+		ImGui::SameLine();
+		if (ImGui::Button("RESET##2", ImVec2(ImGui::GetContentRegionAvail().x, NULL)))
+		{
+
+		}
+
+		//---------------------------------------------------------------------------------------------------
+
+		ImGui::Toggle("LeftHand");
+		window->DC.CursorPos.x = ToolLocation.x;
+		ImGui::SameLine();
+		ImGui::ColorEdit4("##advbarthhbthbtr", (float*)&CaneHandle_picker, ImGuiColorEditFlags_AlphaBar | ImGuiColorEditFlags_AlphaPreviewHalf | ImGuiColorEditFlags_NoInputs);
+		ImGui::SameLine();
+		if (ImGui::Button("RESET##3", ImVec2(ImGui::GetContentRegionAvail().x, NULL)))
+		{
+
+		}
+
+		//---------------------------------------------------------------------------------------------------
+
+		ImGui::Toggle("HeadOutline");
+		window->DC.CursorPos.x = ToolLocation.x;
+		ImGui::SameLine();
+		ImGui::ColorEdit4("##zdfbnhzadfdgaehtsarn", (float*)&CaneHandle_picker, ImGuiColorEditFlags_AlphaBar | ImGuiColorEditFlags_AlphaPreviewHalf | ImGuiColorEditFlags_NoInputs);
+		ImGui::SameLine();
+		if (ImGui::Button("RESET##4", ImVec2(ImGui::GetContentRegionAvail().x, NULL)))
+		{
+
+		}
+
+		//---------------------------------------------------------------------------------------------------
+
+		ImGui::Toggle("Ears");
+		window->DC.CursorPos.x = ToolLocation.x;
+		ImGui::SameLine();
+		ImGui::ColorEdit4("##dzsfnaarthnsmst", (float*)&CaneHandle_picker, ImGuiColorEditFlags_AlphaBar | ImGuiColorEditFlags_AlphaPreviewHalf | ImGuiColorEditFlags_NoInputs);
+		ImGui::SameLine();
+		if (ImGui::Button("RESET##5", ImVec2(ImGui::GetContentRegionAvail().x, NULL)))
+		{
+
+		}
+
+		//---------------------------------------------------------------------------------------------------
+
+		ImGui::Toggle("Hat");
+		window->DC.CursorPos.x = ToolLocation.x;
+		ImGui::SameLine();
+		ImGui::ColorEdit4("##dvfbanrthsrtym", (float*)&CaneHandle_picker, ImGuiColorEditFlags_AlphaBar | ImGuiColorEditFlags_AlphaPreviewHalf | ImGuiColorEditFlags_NoInputs);
+		ImGui::SameLine();
+		if (ImGui::Button("RESET##6", ImVec2(ImGui::GetContentRegionAvail().x, NULL)))
+		{
+
+		}
+
+		//---------------------------------------------------------------------------------------------------
+
+		ImGui::Toggle("Backpack");
+		window->DC.CursorPos.x = ToolLocation.x;
+		ImGui::SameLine();
+		ImGui::ColorEdit4("##zdngbtrazbgdzshrt", (float*)&CaneHandle_picker, ImGuiColorEditFlags_AlphaBar | ImGuiColorEditFlags_AlphaPreviewHalf | ImGuiColorEditFlags_NoInputs);
+		ImGui::SameLine();
+		if (ImGui::Button("RESET##7", ImVec2(ImGui::GetContentRegionAvail().x, NULL)))
+		{
+
+		}
+
+		//---------------------------------------------------------------------------------------------------
+
+	}
+
+	if (ImGui::Toggle(" RGB SLY ", &bRGB_SLY))
+	{
+		// on deactivate restore sky outline to normal
+		if (!bRGB_SLY)
+			ChangeBaseOutlineColor(offsets.EntityOutlineColors, defaultColor);
+	}
+
+	ImGui::Spacing();
+	ImGui::Separator();
+	ImGui::Spacing();
+
+	if (ImGui::Button("Test Read Memory", ImVec2(ImGui::GetWindowContentRegionWidth(), 20)))
+	{
+		auto address = offsets.CustomColors;
+
+		auto value = g_Engine->PS2Read<int>(address);
+
+		g_Console->printdbg("Test Read Memory Address: %llX\nVALUE: [%08X]\n\n", Console::Colors::blue, address, value);
+	}
+
+	if (ImGui::Button("Test Write Memory", ImVec2(ImGui::GetWindowContentRegionWidth(), 20)))
+	{
+
+		auto address = offsets.CustomColors;
+
+		unsigned int value = g_Engine->PS2Read<int>(address);
+
+		if (value != NULL)
+			g_Engine->PS2Write<int>(address, NULL);
+		else
+			g_Engine->PS2Write<int>(address, 0xAC910268);
+
+		g_Console->printdbg("Test Write Memory: %llX\nVALUE: [%08X]\n\n", Console::Colors::blue, address, g_Engine->PS2Read<int>(address));
+
+	}
+
+	if (ImGui::Button("Display Offsets Data", ImVec2(ImGui::GetWindowContentRegionWidth(), 20)))
+		g_Console->printdbg("[+] LOG::OffsetData\n%s", Console::Colors::DEFAULT, offsets.LogData().c_str());
+
+
+*/

--- a/modules/Sly Cooper and the Thievius Raccoonus/SlyCooper_package.h
+++ b/modules/Sly Cooper and the Thievius Raccoonus/SlyCooper_package.h
@@ -19,13 +19,31 @@ namespace PlayStation2
 		// --------------------------------------------------
 		// # Forwards
 		// --------------------------------------------------
+		typedef int8_t		i8_t;
+		typedef uint8_t		u8_t;
+		typedef int16_t		i16_t;
+		typedef uint16_t	u16_t;
+		typedef int32_t		i32_t;
+		typedef uint32_t	u32_t;
+		typedef int64_t		i64_t;
+		typedef uint64_t	u64_t;
+		
 
 		// --------------------------------------------------
 		// # Global functions
 		// --------------------------------------------------
+
+		namespace Dumper
+		{
+			void DumpOffsets();
+			void DumpClasses();
+			void DumpFunctions();
+			void DumpGlobals();
+			void DumpAll();
+		}
 	}
 }
 #pragma pack(pop)
-
+#include <PCSX2/CDK.h>
 #include "SlyCooper_structs.h"
 #include "SlyCooper_classes.h"

--- a/modules/Sly Cooper and the Thievius Raccoonus/SlyCooper_structs.h
+++ b/modules/Sly Cooper and the Thievius Raccoonus/SlyCooper_structs.h
@@ -2,7 +2,7 @@
 
 /**
  * Name: PlayStation2 - PCSX2 :: Sly Cooper and the Thievous Racoonus
- * Version: 0.0.1
+ * Version: 0.0.2
  * Author: NightFyre
 
 RESOURCES & CREDITS: Sly Cooper Modding Server
@@ -16,84 +16,132 @@ namespace PlayStation2
 {
 	namespace SlyCooper 
 	{
-		enum JTStates : int 
-		{
-			JT_Stand = 0,			//	0
-			JT_Run,					//	1
-			JT_Jump,				//	2
-			JT_Hang,				//	3
-			JT_Zap,					//	4
-			JT_SideStep,			//	5
-			JT_Hide,				//	6
-			JT_Pipe,				//	7
-			JT_Edge,				//	8
-			JT_Celebrate,			//	9
-			JT_Rush,				//	10
-			JT_Puppet,				//	11
-			JT_Peek,				//	12
-			JT_Ski,					//	13
-			JT_Ball,				//	14
-		};
 
-		enum JTBodyStates : int 
+		namespace Offsets
 		{
-			Jump_Init = 0,			//	0
-			Jump_Rise,				//	1
-			Jump_Fall,				//	2
-			Jump_Boost,				//	3
-			Jump_In,				//	4
-			Jump_Out,				//	5
-			Jump_Thrown,			//	6
-			Jump_Smash,				//	7
-			Jump_Dive,				//	8
-			Jump_Target,			//	9
-			Jump_Spire,				//	10
-			Jump_Rail,				//	11
-			Jump_Hshape,			//	12
-			Jump_Hpnt,				//	13
-			Hide_Stand,				//	14
-			Hide_Sidestep,			//	15
-			Hide_PeekLeft,			//	16
-			Hide_PeekRight,			//	17
-			Hide_Run,				//	18
-			Hide_Spin,				//	19
-			Pipe_Init,				//	20
-			Pipe_Stay,				//	21
-			Pipe_Up,				//	22
-			Pipe_Down,				//	23
-			Pipe_Spin,				//	24
-			Celebrate_Key,			//	25
-			Celebrate_Timed,		//	26
-			Celebrate_UseKey,		//	27
-			Rush_Attack,			//	28
-			Rush_Bounce,			//	29
-			Peek_Enter,				//	30
-			Peek_Peek,				//	31
-			Peek_Exit,				//	32
-			Zap_Blunt,				//	33
-			Zap_Electric,			//	34
-			Zap_Fire,				//	35
-			Zap_Water,				//	36
-			Zap_Crush,				//	37
-			Zap_Pit,				//	38
-			Zap_Thrown,				//	39
-			Zap_Dead,				//	40
-			Zap_DeadFront,			//	41
-			Zap_DeadInWater,		//	42
-		};
+			static const u32_t o_GameState = 0x2623C0;				//	GameState
+			static const u32_t o_WorldState = 0x2623C4;				//  WorldState
+			static const u32_t o_LevelState = 0x2623C8;				//  LevelState
+			static const u32_t o_JT = 0x262E10;						//  SlyPointer
+			static const u32_t oCM = 0x261990;						//  CameraPointer	
+			static const u32_t o_CustomColors = 0x126A64;			//	CustomColors
+			static const u32_t o_EntityOutlineColor = 0x2623E0;		//	EntityOutlineColor
+		}
 
-		enum JTCaneStates : int 
+		namespace Enums
 		{
-			Reach,					//	0
-			Hang,					//	1
-			Pipe,					//	2
-			SweepInit,				//	3
-			SweepFore,				//	4
-			SweepBack,				//	5
-			StandingSweepFore,		//	6
-			StandingSweepBack,		//	7
-			Max,					//	8
-		};
+			enum class JT_BODYPART_OUTLINE_INDEX : int32_t
+			{
+				Head = 0,
+				Ears, 
+				Hat,
+				Backpack,
+				Body,
+				LeftHand,
+				CaneHandle,
+				CaneHook
+			};
+
+			enum class JT_STATES_INDEX : int32_t
+			{
+				JT_Stand = 0,			//	0
+				JT_Run,					//	1
+				JT_Jump,				//	2
+				JT_Hang,				//	3
+				JT_Zap,					//	4
+				JT_SideStep,			//	5
+				JT_Hide,				//	6
+				JT_Pipe,				//	7
+				JT_Edge,				//	8
+				JT_Celebrate,			//	9
+				JT_Rush,				//	10
+				JT_Puppet,				//	11
+				JT_Peek,				//	12
+				JT_Ski,					//	13
+				JT_Ball,				//	14
+			};
+
+			enum class JT_BODY_STATES_INDEX : int32_t
+			{
+				Jump_Init = 0,			//	0
+				Jump_Rise,				//	1
+				Jump_Fall,				//	2
+				Jump_Boost,				//	3
+				Jump_In,				//	4
+				Jump_Out,				//	5
+				Jump_Thrown,			//	6
+				Jump_Smash,				//	7
+				Jump_Dive,				//	8
+				Jump_Target,			//	9
+				Jump_Spire,				//	10
+				Jump_Rail,				//	11
+				Jump_Hshape,			//	12
+				Jump_Hpnt,				//	13
+				Hide_Stand,				//	14
+				Hide_Sidestep,			//	15
+				Hide_PeekLeft,			//	16
+				Hide_PeekRight,			//	17
+				Hide_Run,				//	18
+				Hide_Spin,				//	19
+				Pipe_Init,				//	20
+				Pipe_Stay,				//	21
+				Pipe_Up,				//	22
+				Pipe_Down,				//	23
+				Pipe_Spin,				//	24
+				Celebrate_Key,			//	25
+				Celebrate_Timed,		//	26
+				Celebrate_UseKey,		//	27
+				Rush_Attack,			//	28
+				Rush_Bounce,			//	29
+				Peek_Enter,				//	30
+				Peek_Peek,				//	31
+				Peek_Exit,				//	32
+				Zap_Blunt,				//	33
+				Zap_Electric,			//	34
+				Zap_Fire,				//	35
+				Zap_Water,				//	36
+				Zap_Crush,				//	37
+				Zap_Pit,				//	38
+				Zap_Thrown,				//	39
+				Zap_Dead,				//	40
+				Zap_DeadFront,			//	41
+				Zap_DeadInWater,		//	42
+			};
+
+			enum class JT_CANE_STATES_INDEX : int32_t
+			{
+				Reach,					//	0
+				Hang,					//	1
+				Pipe,					//	2
+				SweepInit,				//	3
+				SweepFore,				//	4
+				SweepBack,				//	5
+				StandingSweepFore,		//	6
+				StandingSweepBack,		//	7
+				Max,					//	8
+			};
+
+			enum class FGS : int32_t
+			{
+				FirstClue = 0
+			};
+
+			enum class FLS : int32_t
+			{
+				Visited = 0
+			};
+
+			enum class FWS : int32_t
+			{
+				Visited = 0
+			};
+
+		}
+
+		namespace Structs
+		{
+
+		}
 	}
 }
 #pragma pack(pop)


### PR DESCRIPTION
This pull request introduces a significant refactor and modernization of the Sly Cooper module's codebase, focusing on improved organization, type safety, and extensibility. The changes include restructuring class and enum definitions, centralizing offset management, and introducing new utility functions and type aliases. Legacy offset logic and related functions have been removed from the code, and new class representations for game structures have been added.

### Refactoring and Code Organization

* The legacy `Offsets` class and its related functions have been removed from `SlyCooper_classes.h` and replaced with a new `Classes` namespace containing detailed class definitions (`JT`, `CM`, `LS`, `WS`, `GS`) for in-game structures. These new classes use more precise types and padding to match the game's memory layout.
* All offset constants have been centralized in a new `Offsets` namespace within `SlyCooper_structs.h`, improving maintainability and clarity.

### Type Safety and Enums

* Strongly-typed enums (using `enum class`) for various game states and body part indices have been introduced in the new `Enums` namespace, replacing older unscoped enums and improving type safety. [[1]](diffhunk://#diff-953512bae1476e897ad7eb980f2e77ea961e1b97d181a6a6dfb0540e051d4ad5L19-R45) [[2]](diffhunk://#diff-953512bae1476e897ad7eb980f2e77ea961e1b97d181a6a6dfb0540e051d4ad5L38-R64) [[3]](diffhunk://#diff-953512bae1476e897ad7eb980f2e77ea961e1b97d181a6a6dfb0540e051d4ad5L85-R111) [[4]](diffhunk://#diff-953512bae1476e897ad7eb980f2e77ea961e1b97d181a6a6dfb0540e051d4ad5R123-R144)
* New type aliases for integer types (`i8_t`, `u32_t`, etc.) have been added to `SlyCooper_package.h` for consistency across the codebase.

### Utility and Forwarding

* A new `Dumper` namespace is introduced in `SlyCooper_package.h` with function prototypes for dumping offsets, classes, functions, globals, and all data, laying the groundwork for future debugging and introspection tools.

### File and Version Updates

* The module version is incremented from `0.0.1` to `0.0.2` in both `SlyCooper_classes.h` and `SlyCooper_structs.h` to reflect the breaking changes and improvements. [[1]](diffhunk://#diff-8660cea5ecfe1a0c2c65cfe619796aef02ea9a5db8c4f2ab3e8a75e502b13bceL6-R6) [[2]](diffhunk://#diff-953512bae1476e897ad7eb980f2e77ea961e1b97d181a6a6dfb0540e051d4ad5L5-R5)
* The main include in `SlyCooper_package.cpp` is updated to use `SlyCooper_Package.h`, and legacy offset logic and related functions are commented out for archival purposes. [[1]](diffhunk://#diff-5387b440fc6e661c488b1abadd91cb09851bbe8bb72905fb6a00feddae4e3971L2-R2) [[2]](diffhunk://#diff-5387b440fc6e661c488b1abadd91cb09851bbe8bb72905fb6a00feddae4e3971L20-R64)

These changes collectively modernize the codebase, making it easier to maintain and extend for future development and modding efforts.