### PR TITLE
Add SOCOM 2 module with classes and structs

### DIFF
--- a/modules/SOCOM 2 U.S Navy Seals/README.md
+++ b/modules/SOCOM 2 U.S Navy Seals/README.md
@@ -1,0 +1,4 @@
+# SOCOM 2: U.S. Navy Seals
+
+SERIAL: SCUS-97275
+CRC: 	0F6FC6CF

--- a/modules/SOCOM 2 U.S Navy Seals/SOCOM2_Classes.h
+++ b/modules/SOCOM 2 U.S Navy Seals/SOCOM2_Classes.h
@@ -1,0 +1,1015 @@
+#pragma once
+
+/**
+ * Name: SOCOM 2
+ * Platform: PlayStation 2
+ * PCSX2 Version: 1.7 beta
+ * Author: NightFyre
+*/
+
+#pragma pack(push, 0x01)
+namespace PlayStation2
+{
+	namespace SOCOM2
+	{
+
+		namespace Offsets
+		{
+			///	POINTERS
+			//static const unsigned __int32 o_LocalSeal{ 0x44D648 };						//
+			static const unsigned __int32 p_EntityArray{ 0x442CEC };					//
+			static const unsigned __int32 p_WeaponPTR{ 0x4B8A60 };						//	
+
+			/// VISUALS
+			static const unsigned __int32 RenderFix{ 0x35A2F8 };						//	On = || Default = 
+			static const unsigned __int32 RenderFix2{ 0x35A320 };						//	On = 00000000 || Default = 0x0C0D64C8 (202204360)
+			static const unsigned __int32 NVGFilter{ 0x2169D8 };						//	On = 0 || Default = 0x0C065DD0 (201743824)
+			static const unsigned __int32 fps1{ 0x40C638 };								//	On = || Default = 
+			static const unsigned __int32 fps2{ 0x40C640 };								//	On = || Default = 
+			static const unsigned __int32 Fog{ 0x4093D0 };								//	
+			static const unsigned __int32 MapBrightness1{ 0x4B858C };					//	0x4B4D4C;
+			static const unsigned __int32 MapBrightness2{ 0x4B859C };					//	0x4B4D5C;
+			static const unsigned __int32 MapBrightness3{ 0x4B85AC };					//	0x4B4D6C;
+			static const unsigned __int32 widescreen1{ 0x4A1DB0 };						//	On = || Default = 0x3F800000 (1)
+			static const unsigned __int32 widescreen2{ 0x4A1DC0 };						//	On = || Default = 0x44D80000 (1728.0)
+			static const unsigned __int32 widescreen3{ 0x4A1DC4 };						//	On = || Default = 0x44E40000 (1824.0)
+			static const unsigned __int32 widescreen4{ 0x4A7CEC };						//	On = || Default = 0x3F800000 (1)
+			static const unsigned __int32 CompassX{ 0x407688 };							//	On = || Default = 0x440D4000 (565.0)
+			static const unsigned __int32 CompassY{ 0x40768C };							//	On = || Default = 0x42C80000 (100.0)
+			static const unsigned __int32 crosshairR{ 0x407720 };						//	HEX Float
+			static const unsigned __int32 crosshairG{ 0x407728 };						//	Hex Float
+			static const unsigned __int32 crosshairB{ 0x407730 };						//	Hex Float
+			static const unsigned __int32 playerEntityBrightness{ 0x40C6C0 };			//	
+
+			///	MATCH DATA
+			static const unsigned __int32 ForceStart{ 0x408868 };						//	0x0027E2B0  | DEFAULT: 0x0027DD00
+			static const unsigned __int32 MatchTimer{ 0xC2E614 };						//	DEFAULT = 00124F80
+			static const unsigned __int32 ROOM_NAME_ADDRESS{ 0x1FFBBE0 };				//	
+			static const unsigned __int32 GAME_ENDED_ADDRESS{ 0x694C44 };				//	May need to reset this to 0 after it ends, it seems to persist till the next game and doesn't reset when the player loads i
+			static const unsigned __int32 CURRENT_MAP_ADDRESS{ 0x4417C0 };				//	Text String of MapID, if not in a game then it is set to NONE
+			static const unsigned __int32 SEAL_WIN_COUNTER_ADDRESS{ 0x695388 };			//
+			static const unsigned __int32 TERRORIST_WIN_COUNTER_ADDRESS{ 0x69539C };	//
+
+			//	CHEATS
+			static const unsigned __int32 decAmmoCount{ 0x5C6288 };						//	
+			static const unsigned __int32 decEquipmentCount{ 0x5C94B4 };				//	
+			static const unsigned __int32 PerfectWeapon{ 0x5C5E20 };					//	
+			static const unsigned __int32 RapidFire{ 0x5C81CC };						//	
+			static const unsigned __int32 AimAssistBox{ 0x2175E8 };						//	
+			static const unsigned __int32 wpnSpread{ 0x5BD4E4 };						//	
+			static const unsigned __int32 wpnSpread2{ 0x5C2A0C };						//	
+			static const unsigned __int32 wpnSpread3{ 0x5C36C4 };						//	
+			static const unsigned __int32 wpnRecoil{ 0x5BF238 };						//	
+			static const unsigned __int32 AimAssistBool{ 0x40A370 };					//	
+			static const unsigned __int32 TargetLockDistance{ 0x5B0FF8 };				//	
+			//static const unsigned __int32 ForceLaunch{ 0x408868 };						//	On = 0027E280 || Default = 0027DD00
+
+			//	FUNCTIONS
+			static const unsigned __int32 fnRegisterShotOnTarget{ 0x5AB5F0 };			//	
+		}
+
+		namespace Patches
+		{
+			static const Patch RFix(Offsets::RenderFix, 0x100000DB, 0x106000DB);
+			static const Patch ForceMatch{ Offsets::ForceStart, 0x0027E280,  0x0027DD00 };
+			static const Patch EndlessMatch{ Offsets::MatchTimer, 0xFFFFFFFF,  0x00124F80 };
+			static const Patch NoFog{ Offsets::Fog, 0x0, 0x1 };
+		}
+
+
+		/* */
+
+		class CNode
+		{
+		public:
+			Mat4x4 mMatrix; //0x0000
+			AABB mAABB; //0x0040
+			char pad_0058[8]; //0x0058
+			i32_t vfTable; //0x0060
+			i32_t pParent; //0x0064	CNode*
+			char pad_0068[40]; //0x0068
+			i32_t pName; //0x0090
+			i32_t pNodeEx; //0x0094	CNodeEx*
+			char pad_0098[4]; //0x0098
+			float mOpacity; //0x009C
+			char pad_00A0[4]; //0x00A0
+			int32_t mTickCount; //0x00A4
+			char pad_00A8[12]; //0x00A8
+			i32_t pModel; //0x00B4	CModel*
+			i32_t pModelName; //0x00B8
+
+		public:
+			std::string GetName();
+			CNode* GetParent();
+			class CNodeEx* GetNodeExObject();
+			class CModel* GetModelObject();
+			class CEntity* GetEntityObject();
+			bool IsVisible();
+			void SetVisibility(float opacity);
+			Vec3 GetWorldPos() const;
+			void SetWorldPos(const Vec3& newPos);
+			Mat4x4 GetWorldTM();
+			void SetWorldTM(const Mat4x4& newTM);
+			AABB GetLocalBounds() const;
+			AABB GetWorldBounds() const;
+			Vec3 GetRightVector() const;
+			Vec3 GetUpVector() const;
+			Vec3 GetForwardVector() const;
+			float GetYawAngleRadians() const;
+			float GetYawAngleDegrees() const;
+		}; //Size: 0x00BC
+
+		class CNodeEx
+		{
+		public:
+			i32_t vfTable; //0x0000
+			i32_t pEntity; //0x0004	CEntity*
+
+		public:
+			class CEntity* GetEntity();
+		}; //Size: 0x0008
+
+		class CAppCamera
+		{
+		private:
+			i32_t vfTable; //0x0000
+			char pad_0004[176]; //0x0004
+			i32_t pCamera; //0x00B4	CZCamera*
+			i32_t pNode; //0x00B8	CNode*
+			i32_t pAttachedEntity; //0x00BC	CEntity*
+			char pad_00C0[8]; //0x00C0
+			i32_t pBodypart; //0x00C8	CZBodyPart*
+			char pad_00CC[44]; //0x00CC
+
+		public:
+			static CAppCamera* GetDefaultInstance();
+			bool IsValid();
+			class CZCamera* GetCameraObject();
+			CNode* GetNodeObject();
+			class CEntity* GetAttachedEntity();
+			class CZBodyPart* GetBodyPartObject();
+			void SetAttachedEntity(CEntity* pEntity);
+		}; //Size: 0x00F8
+
+		class CTarget
+		{
+		public:
+			i32_t pEntity; //0x0000	CEntity*
+			Vec3 mOrigin; //0x0004
+			float mDistanceSq; //0x0010
+			float mDistance; //0x0014
+			float mVisiblity; //0x0018
+			float mAware; //0x001C : is -2.f if local player is not visible from the targets POV (eyes , not camera)
+			int32_t mDiHandle; //0x0020
+			char pad_0024[8]; //0x0024
+			uint32_t mTargetBits; //0x002C
+
+		public:
+			class CEntity* GetEntity();
+			bool GetOrigin(Vec3* out);
+			float GetDistance() const;
+			bool IsVisible() const;
+			bool WasRecentlyVisible() const;
+		}; //Size: 0x0030
+
+		class CEntity
+		{
+		public:
+			i32_t vfTable; //0x0000
+			char pad_0004[12]; //0x0004
+			Enums::EENTITY_TYPE mEntityType; //0x0010
+			char pad_0011[3];//0x0011
+			i32_t pName; //0x0014
+			int32_t mUnitsSeenBy; //0x0018
+			Vec3 mOrigin; //0x001C
+			i32_t pNode; //0x0028	CNode*
+			Vec3 mVel_M; //0x002C
+			Vec3 mVel_W; //0x0038
+			Vec3 mVel_R; //0x0044
+			Vec4 mQuat; //0x0050
+			Vec3 mNextVel_W; //0x0060
+			char pad_006C[4]; //0x006C
+			Vec4 mNextQuat; //0x0070
+			Mat4x4 mMatrix; //0x0080
+			i32_t pSealCtrl; //0x00C0	CZSealCtrl*
+			char pad_00C4[4]; //0x00C4
+			Enums::ESEAL_TEAMS mTeamID; //0x00C8
+			float mMaxTargetRange; //0x00CC
+			int32_t mMaxTargetCount; //0x00D0
+			int32_t mTargetCount; //0x00D4
+			i32_t pTargetArray; //0x00D8 CTarget*
+			char pad_00DC[4]; //0x00DC
+			uint32_t mEntityBits; //0x00E0
+			char pad_00E4[284]; //0x00E4
+
+		public:
+			bool IsValid();
+			Enums::EENTITY_TYPE GetEntityType();
+			Vec3 GetOrigin();
+			Mat4x4 GetTM();
+			Enums::ESEAL_TEAMS GetTeamID();
+			std::string GetName();
+			bool GetTargets(std::vector<CTarget*> out);
+			CNode* GetNodeObject();
+
+			/* */
+			bool GetWorldTM(Mat4x4* out);
+			bool SetWorldPos(const Vec3& newPos);
+			bool GetWorldPos(Vec3* out);
+			bool GetLocalBounds(AABB* out);
+			bool GetWorldBounds(AABB* out);
+			bool GetForwardVector(Vec3* out);
+			bool GetRightVector(Vec3* out);
+			bool GetUpVector(Vec3* out);
+
+			/* */
+			float GetAngleDegrees();
+			float GetAngleRadians();
+
+
+		}; //Size: 0x0200
+
+		class CZCamera
+		{
+		private:
+			Mat4x4 mMatrix; //0x0000
+			Vec3 mFogColor; //0x0040
+			float mFOV_h; //0x004C
+			float mFOV_v; //0x0050
+			char pad_0054[236]; //0x0054
+			float mZMin; //0x0140
+			float mZMax; //0x0144
+			float mZScale; //0x0148
+			char pad_014C[4]; //0x014C
+			Vec3 mFrustrum[3]; //0x0150
+			Vec3 mFullFrustrum[6]; //0x0174
+			int32_t mFullFrustrumPoints; //0x01BC
+			Vec2 mSin; //0x01C0
+			Vec2 mCos; //0x01C8
+			Vec2 mTan; //0x01D0
+			Vec2 mCot; //0x01D8
+			char pad_01E0[272]; //0x01E0
+			Mat4x4 mtxWorldToView; //0x02F0
+			Mat4x4 mtxWorldToClip; //0x0330
+			Mat4x4 mtxViewToClip; //0x0370
+			Mat4x4 mtxViewToScreen; //0x03B0
+			char pad_03F0[16]; //0x03F0
+			Mat4x4 N00001225; //0x0400
+			Mat4x4 N000012CF; //0x0440
+
+		public:
+			static CZCamera* GetDefaultInstance();
+			bool IsValid();
+			Mat4x4 GetWorldTM();
+			Mat4x4 GetWorldToViewMatrix();
+			Mat4x4 GetWorldToClipMatrix();
+			Mat4x4 GetViewToClipMatrix();
+			Mat4x4 GetViewToScreenMatrix();
+			Vec3 GetOrigin();
+			Vec3 GetFogColor();
+			float GetFOV_h();
+			float GetFOV_v();
+			bool WorldToScreen(const Vec3& worldOrigin, const Vec2& szScreen, Vec2* screen2D);
+		}; //Size: 0x0480
+
+		class CZBodyPart
+		{
+		private:
+			Vec3 mOrigin; //0x0000
+			i32_t pNode; //0x000C	CNode*
+			Vec3 mNextOrigin; //0x0010
+			i32_t pParent; //0x001C	CZBodyPart*
+			Vec4 mQuat; //0x0020
+			Vec4 mNextQuat; //0x0030
+
+		public:
+			Vec3 GetOrigin() const;
+			CNode* GetNode();
+			CZBodyPart* GetParent();
+			std::string GetName();
+			bool GetLocalTM(Mat4x4* out);
+			Vec3 GetLocalOrigin() const;
+			Vec4 GetLocalRotation() const;
+			bool GetWorldTM(const Mat4x4& model, Mat4x4* out);	// multiply by parent model to get world transform relative to model
+		}; //Size: 0x0040
+
+		class CZSealBody : public CEntity
+		{
+		public:
+			int8_t mZoomIndex; //0x0200
+			int8_t mLastZoomIndex; //0x0201
+			char pad_0202[2]; //0x0202
+			float mZoomModifier; //0x0204
+			char pad_0208[224]; //0x0208
+			i32_t mSkeleton[32]; //0x02E8	CZBodyPart*
+			char pad_0368[12]; //0x0368
+			Enums::ESEAL_STANCE mStance; //0x0374
+			Enums::ESEAL_LEAN mLean; //0x0375
+			char pad_0376[2]; //0x0376
+			float mShoulderRecoil; //0x0378
+			char pad_037C[68]; //0x037C
+			Vec3 mAimWorldPos; //0x03C0
+			char pad_03CC[4]; //0x03CC
+			Vec3 mAimWorldAngles; //0x03D0
+			char pad_03DC[68]; //0x03DC
+			float mLifetime; //0x0420
+			char pad_0424[184]; //0x0424
+			Vec3 mRelativeRotation; //0x04DC
+			char pad_04E8[60]; //0x04E8
+			float mTimeSinceLastAnimation; //0x0524
+			i32_t pAnimationSet; //0x0528	CAnimation*
+			char pad_052C[8]; //0x052C
+			int32_t mAnimationType; //0x0534	Ninja Jump State = 0x12B0140
+			char pad_0538[84]; //0x0538
+			int8_t mHeadshots; //0x058C
+			char pad_058D[3]; //0x058D
+			int8_t mShotsHit; //0x0590
+			char pad_0591[3]; //0x0591
+			int8_t mShotsFired; //0x0594
+			char pad_0595[1]; //0x0595
+			int8_t mWasFiredAt; //0x0596
+			char pad_0597[5]; //0x0597
+			int8_t mWasHit; //0x059C
+			char pad_059D[1]; //0x059D
+			int8_t mDeaths; //0x059E
+			char pad_059F[23]; //0x059F
+			int8_t mEquipmentUsed; //0x05B6
+			char pad_05B7[1]; //0x05B7
+			int8_t mCqCTakedowns; //0x05B8
+			char pad_05B9[1]; //0x05B9
+			int8_t mPrimaryShotsFired; //0x05BA
+			char pad_05BB[1]; //0x05BB
+			int8_t mSecondaryShotsFired; //0x05BC
+			char pad_05BD[67]; //0x05BD
+			Vec2 mRecoilPunch; //0x0600
+			Vec2 mPrevRecoilPunch; //0x0608
+			char pad_0610[8]; //0x0610
+			Vec3 mRifleKick; //0x0618
+			int32_t mFireRilfeKickState; //0x0624
+			int32_t mHeartbeatState; //0x0628
+			Vec2 mHeartbeat; //0x062C
+			int32_t mCurItemReticule; //0x0634
+			Vec2 mScreenOffset; //0x0638
+			char pad_0640[132]; //0x0640
+			i32_t pWeapons[10]; //0x06C4	CZWeapon*
+			char pad_06EC[80]; //0x06EC
+			i32_t pAmmoTypes[10]; //0x073C	CZAmmo*
+			char pad_0764[120]; //0x0764
+			int32_t mPrimaryMags[10]; //0x07DC
+			int32_t mSecondaryMags[10]; //0x0804
+			int32_t mEqSlot1Ammo; //0x082C
+			char pad_0830[36]; //0x0830
+			int32_t mEqSlot2Ammo; //0x0854
+			char pad_0858[36]; //0x0858
+			int32_t mEqSlot3Ammo; //0x087C
+			char pad_0880[996]; //0x0880
+			int32_t mPrimaryMagIndex; //0x0C64
+			int32_t mSecondaryMagIndex; //0x0C68
+			char pad_0C6C[112]; //0x0C6C
+			int32_t mWeaponFireTypes[2]; //0x0CDC
+			char pad_0CE4[276]; //0x0CE4
+			int32_t mWeaponFireCount; //0x0DF8
+			float mWeaponFireDelta; //0x0DFC
+			char pad_0E00[4]; //0x0E00
+			int32_t mCurrentWeaponIndex; //0x0E04
+			char pad_0E08[4]; //0x0E08
+			int32_t mMaxWeaponIndex; //0x0E0C
+			i32_t pEntity; //0x0E10	CEntity*
+			char pad_0E14[152]; //0x0E14
+			i32_t pCarry; //0x0EAC	CEntity*
+			char pad_0EB0[168]; //0x0EB0
+			float mElevation; //0x0F58
+			char pad_0F5C[232]; //0x0F5C
+			float mHealth; //0x1044
+			char pad_1048[1016]; //0x1048
+			Vec3 mAimDir; //0x1440
+			Vec3 mAimGoal; //0x144C
+			Vec3 mAimPoint; //0x1458
+			Vec3 mReticlePt; //0x1464
+			Vec3 mAimNorm; //0x1470
+			Vec3 mPrevAimPoint; //0x147C
+			Vec3 mPrevAimNorm; //0x1488
+			Vec3 mPrevReticlePt; //0x1494
+			Vec3 mCurrAimPos; //0x14A0
+			int32_t N000007EA; //0x14AC
+			Vec3 mCurFirePos; //0x14B0
+			int32_t N000007EC; //0x14BC
+			Vec3 mSkeletonRoot; //0x14C0
+
+		
+		public:
+			static CZSealBody* GetDefaultInstance();
+			bool IsValidSeal();
+			float GetHealth();
+			bool IsAlive();
+			Enums::ESEAL_STANCE GetStance();
+			bool GetBoneByIndex(const int& boneIndex, CZBodyPart** out);
+			bool GetBoneWorldTM(const int& boneIndex, Mat4x4* out);
+			bool GetBoneLocationByIndex(const int& boneIndex, Vec3& outPosition);
+			void SetAimPoint(const Vec3& newAim);
+			bool SetAimTarget(CZSealBody* pTarget, bool bVisible = false, const Enums::ESEALBONES_INDEX& bone = Enums::ESEALBONES_head);
+			bool SetAimTarget(const Vec3& location);
+			CTarget* GetTargetEntity(CZSealBody* pTarget); // returns pointer to target struct if the passed entity is within the target array
+		}; //Size: 0x1390
+
+		/* */
+
+
+		class CZWorld
+		{
+		private:
+		public:
+		};
+
+		class CCamera
+		{
+		private:
+			char								pad_0000[80];	//0x0000
+			Vec3								Position;		//0x0050
+			unsigned int						m_viewType;				//0x005C	//	0 = normal view : 2+ = zoom of sorts
+
+		public:
+			std::string LogData();
+
+		public:
+			CCamera* GetDefaultInstance();
+		
+			Vec3 GetPosition();
+		};
+
+		class CZSealObject
+		{
+		private:
+			char								pad_0000[48];	//0x0000
+			Vec3								m_absPosition;	//0x0030
+			//	char								pad_003C[96];	//0x003C
+			//	float								m_selfVisible;	//0x009C	//	255 = visible : 0 = invisible
+
+		public:
+			static CZSealObject*				GetDefaultInstance();
+			Vec3								GetPosition();
+			void								SetPosition(Vec3 in);
+
+		};	//Size: 0x0100
+
+		class CZSeal
+		{
+		public:
+			i32_t								vfTable;					//0x0000	//	0x668B20
+			char								pad_0004[12];				//0x0004
+			__int32								m_ID;						//0x0010
+			__int32								m_pName;					//0x0014
+			char								pad_0018[4];				//0x0018
+			Vec3								m_relativeLocation;			//0x001C
+			unsigned __int32					m_pSealObj;					//0x0028		
+			char								pad_002C[40];				//0x002C
+			Vec3								rotation;					//0x0054 // x = right, z = left
+			//	float								LookSpeedRight;				//0x0054
+			//	char								pad_0058[4];				//0x0058
+			//	float								LookSpeedLeft;				//0x005C
+			char								pad_0060[60];				//0x0060
+			float								m_sealAlpha;				//0x009C
+			char								pad_00A0[28];				//0x00A0
+			float								m_mapPos;					//0x00BC
+			char								pad_00C0[8];				//0x00C0
+			ETeam								m_teamID;					//0x00C8
+			char								pad_00CC[20];				//0x00CC
+			int									DeadOrAlive;				//0x00E0
+			//char								pad_00E4[828];				//0x00E4
+			char								pad_00E4[284];				//0x00E4
+			__int32								m_CameraViewType;			//0x0200
+			float								m_ZoomLevel;				//0x0204
+			char								pad_0208[536];				//0x0208
+			float								m_GameTime;					//0x0420
+			char								pad_0424[256];				//0x0424
+			float								m_TimeSinceLastAnimation;	//0x0524
+			__int32								m_AnimationSet1;			//0x0528
+			__int32								m_AnimationSet2;			//0x052C
+			__int32								m_AnimationSet3;			//0x0530
+			__int32								m_CurrentAnimation;			//0x0534
+			char								pad_0538[8];				//0x0538
+			__int32								m_UIChartType;				//0x0540
+			char								pad_0544[76];				//0x0544
+			__int32								m_shotsHit;					//0x0590
+			__int32								m_shotsFired;				//0x0594
+			__int32								m_totalKills;				//0x0598
+			//	char								pad_059C[296];				//0x059C	//	BEGIN NEW
+			char								pad_059C[60];				//0x059C
+			Vec2								m_recoilParams;				//0x05D8
+			char								pad_05E0[36];				//0x05E0
+			float								m_Recoil;					//0x0604
+			Vec2								m_scopeSwayParams;			//0x0608
+			char								pad_0610[12];				//0x0610
+			Vec2								m_scopeRecoilParams;		//0x061C
+			char								pad_0624[160];				//0x0624	//	END NEW
+			EWeapon								m_PrimaryWeapon;			//0x06C4
+			EWeapon								m_SecondaryWeapon;			//0x06C8
+			EWeapon								m_EqSlot1;					//0x06CC
+			EWeapon								m_EqSlot2;					//0x06D0
+			EWeapon								m_EqSlot3;					//0x06D4
+			char								pad_06D8[100];				//0x06D8
+			__int32								m_PrimaryAmmoType;			//0x073C
+			__int32								m_SecondaryAmmoType;		//0x0740
+			__int32								m_EqSlot1AmmoType;			//0x0744
+			__int32								m_EqSlot2AmmoType;			//0x0748
+			__int32								m_EqSlot3AmmoType;			//0x074C
+			char								pad_0750[100];				//0x0750
+			__int32								m_PrimaryMags[10];			//0x07B4
+			__int32								m_SecondaryMags[10];		//0x07DC
+			__int32								m_EqSlot1Ammo;				//0x0804
+			char								pad_0808[36];				//0x0808
+			__int32								m_EqSlot2Ammo;				//0x082C
+			char								pad_0830[36];				//0x0830
+			__int32								m_EqSlot3Ammo;				//0x0854
+			char								pad_0858[1156];				//0x0858
+			//char									pad_0858[28];			//0x0858
+			//int									EQSlot2Mag;				//0x0874
+			//char									pad_0878[36];			//0x0878
+			//int									EQSlot3Mag;				//0x089C
+			//char									pad_08A0[1084];			//0x08A0
+			__int32								m_PrimaryFireType;			//0x0CDC
+			__int32								m_SecondaryFireType;		//0x0CE0
+			char								pad_0CE4[276];				//0x0CE4
+			__int32								m_isTriggerPressed;			//0x0DF8
+			__int32								m_fireCooldown;				//0x0DFC
+			char								pad_0E00[44];				//0x0E00
+			Vec2								m_xhairSpreadParams;		//0x0E2C
+			//	float								m_xhairSpread;				//0x0E2C
+			//	float								m_xhairBloom;				//0x0E30
+			char								pad_0E34[84];				//0x0E34
+			unsigned __int32					m_pObjectAtCrosshair;		//0x0E88
+			//	char								m_pad_0E8C[308];			//0x0E8C
+			char								pad_0E8C[232];				//0x0E8C
+			int									m_GunHot_unk;				//0x0F74
+			char								pad_0F78[72];				//0x0F78
+			__int32								m_causeOfDeathWeaponID;		//0x0FC0
+			char								pad_0FC4[8];				//0x0FC4
+			__int32								m_respawn;					//0x0FCC
+			char								pad_0FD0[116];				//0x0FD0
+			float								m_health;					//0x1044
+			char								pad_1048[4];				//0x1048
+			__int32								m_shock;					//0x104C
+			char								pad_1050[12];				//0x1050
+			__int32								m_fallDamage;				//0x105C
+			char								pad_1060[260];				//0x1060
+			__int32								m_gunHot1;					//0x1164
+			char								pad_1168[4];				//0x1168
+			__int32								m_gunHot2;					//0x116C
+			char								pad_1170[504];				//0x1170
+			__int32								m_jumpHeight;				//0x1368
+
+		public:
+			static CZSeal*						GetDefaultInstance();
+		
+		public:
+			bool								IsValid();
+			CZSealObject*						GetSealObject();
+			Vec3								GetPosition();
+			Vec2								GetRotation();
+			std::string							GetName();
+			ETeam								GetTeam();
+			float								GetHealth();
+			bool								IsAlive();
+			void								ChangeTeams(ETeam newTeamID);
+			CZKit								GetKit();
+			void								UpdateKit(CZKit newKit);
+		};	//Size: 0x136C
+
+		class CZWeapon
+		{
+		private:
+			/*
+
+				- Core
+				-- GiveAmmo
+				-- GiveWeapon
+				-- GetLoadoutData | Primary, Secondary, Equipment & Ammo
+
+				- Systems
+				-- Weapon Manager | Slot -> Type -> Weapon : Send
+
+			*/
+
+		public:
+			int32_t vfTable; //0x0000	vTable
+			int32_t pName; //0x0004	char*
+			int32_t pDisplayName; //0x0008	char*
+			int32_t pTextureName; //0x000C	char*
+			char pad_0010[4]; //0x0010
+			int32_t pIconName; //0x0014	char*
+			int32_t pGearName; //0x0018	char*
+			int32_t pModelName; //0x001C	char*
+			int32_t pBulletImpactName; //0x0020	char*
+			Enums::EWEAPON_FIREMODE mMaxFireMode; //0x0024
+			int32_t szMag; //0x0028
+			int32_t defaultMags; //0x002C
+			float mSoundRadius; //0x0030
+			float mSoundRadiusSq; //0x0034
+			Enums::EWEAPON_ENCUMBRANCE Encumbrance; //0x0038
+			char pad_0039[3]; //0x0039
+			float mMaxRange; //0x003C
+			float mEffectiveRange; //0x0040
+			float mMuzzleVelocity; //0x0044
+			float mImpactRadius; //0x0048
+			char pad_004C[4]; //0x004C
+			float mFireWaitTime; //0x0050
+			float mReloadTime; //0x0054
+			char pad_0058[12]; //0x0058
+			float mDamageModifier; //0x0064
+			char pad_0068[20]; //0x0068
+			int32_t mID; //0x007C
+			char pad_0080[28]; //0x0080
+			int32_t pName_ReloadAnim; //0x009C	char*
+			char pad_00A0[4]; //0x00A0
+			int32_t N000000DB; //0x00A4	char*
+			int32_t pName_HitAnim; //0x00A8	char*
+			int32_t pName_FireAnim; //0x00AC	char*
+			int32_t pName_ZoomAnim; //0x00B0	char*
+			int32_t pName_DefaultSpecialAnim; //0x00B4	char*
+			char pad_00B8[12]; //0x00B8
+			ZArray<class CZAmmo*> mLegalAmmoList; //0x00C4
+			bool bHasFireMode[4]; //0x00D0
+			char pad_00D4[36]; //0x00D4
+			float mBloom; //0x00F8
+			float mRecoilResetDelay; //0x00FC
+			float mRecoil; //0x0100
+			char pad_0104[44]; //0x0104
+			float mBloomResetTimer; //0x0130
+			char pad_0134[348]; //0x0134
+
+		public:	//	static methods
+			static CZWeapon*					GetDefaultInstance();
+
+		public:	//	instance methods
+			Vec3								GetBulletPos();
+			void								SetBulletPos(Vec3 Pos);
+		};	//Size:	0x0290
+
+		class CZAmmo
+		{
+		public:
+			i32_t pName; //0x0000	char*
+			i32_t pDisplayName; //0x0004	char*
+			i32_t pName2; //0x0008	char*
+			float mImpactDmg; //0x000C
+			float mStun; //0x0010
+			float mPiercing; //0x0014
+			float mExplosionDmg; //0x0018
+			float mExplosionRadius; //0x001C
+			char pad_0020[16]; //0x0020
+			int32_t mID; //0x0030
+			char pad_0034[28]; //0x0034
+
+		}; //Size: 0x0048
+
+		class ZListWeapons
+		{
+		public:
+			class CZWeapon mList1[5]; //0x0000
+			char pad_0CD0[32]; //0x0CD0
+			class CZWeapon mList2[6]; //0x0CF0
+			char pad_1C50[32]; //0x1C50
+			class CZWeapon mList3[43]; //0x1C70
+			char pad_8AA0[32]; //0x8AA0
+			class CZWeapon mList4[25]; //0x8AC0
+			char pad_CAD0[64]; //0xCAD0
+			class CZWeapon mList5[7]; //0xCB10
+		}; //Size: 0xDD00
+
+		class CZMatchData
+		{		
+			/*
+			* 
+				NOTES
+				Host
+				- Force Start
+				- 
+				Match Info
+				- Map
+				- Round
+				- Time
+				- Players
+				- Score
+				- ForceHost
+				- ForceStartMatch
+				- ForceEndMatch
+				- MatchNeverEnds
+				- PlayerArray
+				- GetLobbyInfo	| RoomName, MapName, Mode, #Players(Organized by team), Rounds Won/Current Round/Timer
+			*/ 
+		public:	//	OFFSETS
+			const char*							roomName;
+			const char*							currentMap;
+			float								matchTime;
+			int32_t								num_players;
+			int32_t								num_alivePlayers;
+			int32_t								num_spectators;
+			int32_t								num_ai;
+			int32_t								num_teams;
+			int32_t								num_currentRound;
+			CZSeal*								Host;
+			CZSeal*								localPlayer;
+
+		public: //	FUNCTIONS
+			//bool isMatchEnded()
+			//{
+			//	Offsets offset;
+			//	return (PS2Read<int>(offset.GameEndAddress) == NULL) ? TRUE : FALSE;
+			//}
+			static void							ForceStartMatch(bool bActive);
+			static void							SetEndlessMatch(bool bActive);
+			static bool							GetEntities(std::vector<CZSealBody*>* entities);
+			//	static bool							GetPlayers(std::vector<CZSealBody*>* players);
+			//	static std::vector<class CZSealBody*>	GetAlivePlayers();
+			static void							EndCurrentRound();
+			static std::vector<class CZSeal*>	GetPlayers();
+			static bool							GetPlayers(std::vector<class CZSeal*>* out);
+			static std::vector<class CZSeal*>	GetAlivePlayers();
+			static std::string					LogData();
+		};
+
+		/*
+		* 
+			class Offsets_
+			{
+				//	RAW OFFSETS
+			public:
+				/// <summary>
+				int p_Player				= 0x44D648;	//
+				int p_EntityArray			= 0x442CEC;	//
+				int p_WeaponPTR				= 0x4B8A60;	//	
+
+				/// <summary>
+				int RenderFix				= 0x35A2F8;	//	On = || Default = 
+				int RenderFix2				= 0x35A320;	//	On = 00000000 || Default = 0x0C0D64C8 (202204360)
+				int NVGFilter				= 0x2169D8;	//	On = 0 || Default = 0x0C065DD0 (201743824)
+				int fps1					= 0x40C638;	//	On = || Default = 
+				int fps2					= 0x40C640;	//	On = || Default = 
+				int Fog						= 0x4093D0;
+				int MapBrightness1			= 0x4B858C;	//0x4B4D4C;
+				int MapBrightness2			= 0x4B859C;	//0x4B4D5C;
+				int MapBrightness3			= 0x4B85AC;	//0x4B4D6C;
+				int widescreen1				= 0x4A1DB0;	//	On = || Default = 0x3F800000 (1)
+				int widescreen2				= 0x4A1DC0;	//	On = || Default = 0x44D80000 (1728.0)
+				int widescreen3				= 0x4A1DC4;	//	On = || Default = 0x44E40000 (1824.0)
+				int widescreen4				= 0x4A7CEC;	//	On = || Default = 0x3F800000 (1)
+				int CompassX				= 0x407688;	//	On = || Default = 0x440D4000 (565.0)
+				int CompassY				= 0x40768C;	//	On = || Default = 0x42C80000 (100.0)
+				int crosshairR				= 0x407720;	//	HEX Float
+				int crosshairG				= 0x407728;	//	Hex Float
+				int crosshairB				= 0x407730;	//	Hex Float
+				int playerEntityBrightness	= 0x40C6C0;
+
+				///	<MatchData>
+				int	ForceStart				= 0x408868;	//	0x0027E2B0  | DEFAULT: 0x0027DD00
+				int MatchTimer				= 0xC2E614;	//	DEFAULT = 00124F80
+				int ROOM_NAME_ADDRESS		= 0x1FFBBE0;
+				int GAME_ENDED_ADDRESS		= 0x694C44;		// May need to reset this to 0 after it ends, it seems to persist till the next game and doesn't reset when the player loads i
+				int CURRENT_MAP_ADDRESS		= 0x4417C0;		// Text String of MapID, if not in a game then it is set to NONE
+				int SEAL_WIN_COUNTER_ADDRESS = 0x695388;
+				int TERRORIST_WIN_COUNTER_ADDRESS =  0x69539C;
+
+				//	CHEATS
+				int decAmmoCount			= 0x5C6288;
+				int decEquipmentCount		= 0x5C94B4;
+				int PerfectWeapon			= 0x5C5E20;
+				int RapidFire				= 0x5C81CC;
+				int AimAssistBox			= 0x2175E8;
+				int wpnSpread				= 0x5BD4E4;
+				int wpnSpread2				= 0x5C2A0C;
+				int wpnSpread3				= 0x5C36C4;
+				int wpnRecoil				= 0x5BF238;
+				int AimAssistBool			= 0x40A370;
+				int TargetLockDistance		= 0x5B0FF8;
+				int ForceLaunch				= 0x408868;	//	On = 0027E280 || Default = 0027DD00
+
+				//	FUNCTIONS
+				int fnRegisterShotOnTarget	= 0x5AB5F0;
+
+				std::vector<int> OffsetArray = {
+					//	Pointers
+					0x44D648,		//	PlayerPointer
+					0x442CEC,		//	EntityArrayPointer
+					0x4B8A60,		//	WeaponPointer
+
+					//	Environment
+					0x35A2F8,		//	RenderFix1 
+					0x35A320,		//	RenderFix2
+					0x2169D8,		//	NVG
+					0x40C638,		//	FPS
+					0x40C640,		//	FPS2
+					0x4093D0,		//	FOG
+					0x4B858C,		//	MapBrightness1;
+					0x4B859C,		//	MapBrightness2;
+					0x4B85AC,		//	MapBrightness3;
+
+					0x4A1DB0,		//	WideScreen(0)
+					0x4A1DC0,		//	WideScreen(1)
+					0x4A1DC4,		//	WideScreen(2)
+					0x4A7CEC,		//	WideScreen(3)
+
+					0x407688,		//	Compass(x)
+					0x40768C,		//	Compass(y)
+
+					0x407720,		//	Crosshair(r)
+					0x407728,		//	Crosshair(g)
+					0x407730,		//	Crosshair(b)
+
+					// Cheats
+					0x5C6288,		//	decAmmoCount
+					0x5C94B4,		//	decEquipmentCount
+					0x5C5E20,		//	PerfectWeapon
+					0x5C81CC,		//	RapidFire
+					0x2175E8,		//	AimAssistBox
+					0x40A370,		//	AimAssistBool
+					0x5B0FF8,		//	TargetLockDistance
+					0x408868,		//	ForceLaunch
+				};
+
+				std::vector<std::string> names = {
+					"PlayerPointer",
+					"EntityArrayPointer",
+					"WeaponPointer",
+					"RenderFix1",
+					"RenderFix2",
+					"NVG",
+					"FPS",
+					"FPS2",
+					"FOG",
+					"MapBrightness1",
+					"MapBrightness2",
+					"MapBrightness3",
+					"WideScreen(0)",
+					"WideScreen(1)",
+					"WideScreen(2)",
+					"WideScreen(3)",
+					"Compass(x)",
+					"Compass(y)",
+					"Crosshair(r)",
+					"Crosshair(g)",
+					"Crosshair(b)",
+					"decAmmoCount",
+					"decEquipmentCount",
+					"PerfectWeapon",
+					"RapidFire",
+					"AimAssistBox",
+					"AimAssistBool",
+					"TargetLockDistance",
+				};
+				
+			public:	// Auto Resolve List
+				uintptr_t SEALPointer		= PS2Memory::GetAddr(p_Player);
+				uintptr_t WEAPONPointer     = PS2Memory::GetAddr(p_WeaponPTR);
+				uintptr_t EntityArray		= PS2Memory::GetAddr(p_EntityArray);
+				uintptr_t FrameRate1		= PS2Memory::GetAddr(fps1);
+				uintptr_t FrameRate2		= PS2Memory::GetAddr(fps2);
+
+			public:	//	Functions
+				std::string					LogData();
+				class CPlayer*				GetSealObject() { return (CPlayer*)SEALPointer; }
+				class CWeapon*				GetWeaponObject() {return (CWeapon*)WEAPONPointer; }
+				std::vector<class CPlayer*>	GetEntityArray();
+
+			};
+
+
+
+
+			//	@NOTE: deprecated 4/20/24
+			class CPlayerPhysics	//	CZSealBody ??
+			{
+			public:
+				Vec3				unkVecA;		//0x0000
+				char				pad_000C[4];	//0x000C
+				Vec3				unkVecB;		//0x0010
+				char				pad_001C[4];	//0x001C
+				Vec3				unkVecC;		//0x0020
+				char				pad_002C[4];	//0x002C
+				Vec3				absPosition;	//0x0030		
+
+			public:
+				std::string LogData();
+			};
+			
+			//	@NOTE: deprecated 4/20/24
+			class CPlayer
+			{
+			public:	// NATIVE OFFSETS (DO NOT DISRUPT)
+				int					ObjectBase;						//0x0000
+				char				pad_0004[16];					//0x0004
+				int					NamePTR;						//0x0014
+				char				pad_0018[4];					//0x0018
+				Vec3				Position;						//0x001C
+				CPlayerPhysics*		PlayerMovement;					//0x0028
+				char				pad_0030[36];					//0x0030
+				Vec3				Rotation;						//0x0054
+				char				pad_0060[104];					//0x0060
+				int					TeamID;							//0x00C8
+				char				pad_00CC[852];					//0x00CC
+				float				GameTime;						//0x0420
+				char				pad_0424[368];					//0x0424
+				int					ShotsFired;						//0x0594
+				char				pad_0598[64];					//0x0598
+				float				WeaponBounce;					//0x05D8
+				float				WeaponSpread;					//0x05DC
+				char				pad_05E0[36];					//0x05E0
+				float				WeaponRecoil;					//0x0604
+				float				ScopeSway;						//0x0608
+				float				ScopePulse;						//0x060C
+				char				pad_0610[12];					//0x0610
+				float				ScopeBounce;					//0x061C
+				float				ScopeRecoil;					//0x0620
+				char				pad_0624[160];					//0x0624
+				int					PrimaryWeapon;					//0x06C4
+				int					SecondaryWeapon;				//0x06C8
+				int					Equipment1;						//0x06CC
+				int					Equipment2;						//0x06D0
+				int					Equipment3;						//0x06D4
+				char				pad_06D8[100];					//0x06D8
+				int					PrimaryAmmoType;				//0x073C
+				int					SecondaryAmmoType;				//0x0740
+				int					EquipmentType1;					//0x0744
+				int					EquipmentType2;					//0x0748
+				int					EquipmentType3;					//0x074C
+				char				pad_0750[100];					//0x0750
+				int					PrimaryMag[10];					//0x07B4
+				int					SecondaryMag[10];				//0x07DC
+				int					EquipmentSlot1;					//0x0804
+				char				pad_0808[36];					//0x0808
+				int					EquipmentSlot2;					//0x082C
+				char				pad_0830[36];					//0x0830
+				int					EquipmentSlot3;					//0x0854
+				char				pad_0858[1440];					//0x0858
+				int					weaponAUTO;						//0x0DF8
+				int					weaponRAPID;					//0x0DFC
+				char				pad_0E00[44];					//0x0E00
+				float				CrosshairSpread;				//0x0E2C
+				float				CrosshairBloom;					//0x0E30
+				char				pad_0E34[320];					//0x0E34
+				int					GunHot;							//0x0F74
+				char				pad_0F78[204];					//0x0F78
+				float				Health;							//0x1044
+
+			public:	//	FUNCTIONS
+				bool				IsValid();
+				bool				IsAlive();
+				CPlayerPhysics*		PlayerPhysicsPtr();
+				std::string			GetPlayerName();
+				std::string			GetTeamName();
+				void				ChangeTeam(unsigned int newTeam);
+				std::string			GetWeaponName(unsigned int Weapon);
+				std::string			GetAmmoTypeName(unsigned int AmmoType);
+				std::string			GetLoadoutInformation();
+				void				GiveAmmo(int amount, int mags = {});
+				void				GiveWeapon(unsigned int Slot, unsigned int Weapon);
+				void				RemoveWeaponsandAmmo();
+				void				Teleport(Vec3 Pos);
+				std::string			LogData();
+				Vec3				GetPosition()				{ return this->Position; }
+				void				SetPosition(Vec3 in)		{ this->Position = in; }
+				Vec2				GetRotation()				{ return Vec2(this->Rotation.x, this->Rotation.z); }
+				void				SetPosition(Vec2 in)		{ Vec2(this->Rotation.x, this->Rotation.z) = in; }
+				ETeam				GetTeam()					{ return (ETeam)this->TeamID; }
+				float				GetHealth()					{ return (this->Health * 100.f); }
+				EPrimaryWeapon		GetPrimaryWeapon()			{ return (EPrimaryWeapon)this->PrimaryWeapon; }
+				ESecondaryWeapon	GetSecondaryWeapon()		{ return (ESecondaryWeapon)this->SecondaryWeapon; }
+				EEquipment			GetEquipmentItem(char slot = 0);
+				void				SetPrimaryWeapon(EPrimaryWeapon weapon)		{ this->PrimaryWeapon = weapon; }
+				void				SetSecondaryWeapon(ESecondaryWeapon weapon) { this->SecondaryWeapon = weapon; }
+				void				SetEquipment(EEquipment equipment, char slot = 0);
+				bool				isFriendly(class CPlayer* otherEnt);
+
+				//	Need to get helper functions to obtain primary ammo type and max ammo counts
+				void				RefillPrimaryAmmo();
+				void				RefillSecondaryAmmo();
+				void				RefillEquipmentAmmo();
+			};
+
+
+			//class Patches : public Offsets
+			//{
+			//public:
+			//	void					SetBrightness(float fLevel);
+			//	void					GetBrightnessLevel(float& out);
+			//	float					GetBrightnessLevel();
+			//	void					ResetBrightness();
+			//	void					SetFPS(int iFPS);
+			//	void					GetCurrentFPS(int& out);
+			//	int						GetCurrentFPS();
+			//	void					ResetFPS();
+			//	void					SetCrosshairColor();
+			//	void					GetCurrentCrosshairColor(Vec3& out);
+			//	Vec3					GetCurrentCrosshairColor();
+			//	void					ResetCrosshairColor();
+			//	void					ToggleAimAssist(bool iValue);
+			//	bool					IsAimAssistEnabled();
+			//	void					SetCompassPosition(Vector2 in);
+			//	void					GetCompassPosition(Vector2& out);
+			//	void					DisableEyeAdjustment();
+			//	void					RestoreEyeAdjustment();
+			//};
+		
+		*/
+	}
+}
+#pragma pack(pop)

--- a/modules/SOCOM 2 U.S Navy Seals/SOCOM2_Structs.h
+++ b/modules/SOCOM 2 U.S Navy Seals/SOCOM2_Structs.h
@@ -1,0 +1,771 @@
+#pragma once
+
+/**
+ * Name: SOCOM 2
+ * Platform: PlayStation 2
+ * PCSX2 Version: 1.7 beta
+ * Author: NightFyre
+*/
+
+#pragma pack(push, 0x01)
+namespace PlayStation2
+{
+	//	@TODO: include in CDK source
+	struct Patch
+	{
+	public:
+		unsigned __int32 dst;
+		unsigned __int32 patch;
+		unsigned __int32 original;
+
+		Patch(unsigned __int32 d, unsigned __int32 p, unsigned __int32 o) : dst(d), patch(p), original(o) {};
+	};
+
+	namespace SOCOM2
+	{
+
+		namespace Offsets
+		{
+			/* */
+
+			/* */
+			static const i32_t o_LocalCAppCamera{ 0x4429B0 };				//
+			static const i32_t o_LocalSeal{ 0x44D648 };						//
+			static const i32_t o_pEntityArray{ 0x442CE8 };					//	ZArray<CEntity*>
+		
+			/* */
+			static const i32_t p_WeaponManager{ WEAPON_MODEL_18 };			//	ZWeaponList
+			static const i32_t p_AmmoManager{ AMMO_9x19P };					//	CZAmmo*[]
+		}
+
+		namespace Enums
+		{
+			enum EENTITY_TYPE : char
+			{
+				ENT_TYPE_UNKNOWN,
+				ENT_TYPE_RECYCLE,
+				ENT_TYPE_SEAL,
+				ENT_TYPE_TURRET
+			};
+
+			enum EPICKUP_TYPE : __int8
+			{
+				PICKUP_TYPE_ANIM = 1,
+				PICKUP_TYPE_WEAPON = 8,
+				PICKUP_TYPE_AMMO,
+				PICKUP_TYPE_BOMB = 11
+			};
+
+			enum EPROJECTILE_TYPE
+			{
+				PROJECTILE_TYPE_NORMAL,
+				PROJECTILE_TYPE_ONE_FRAME,
+				PROJECTILE_TYPE_ONE_FRAME_SHOTGUN
+			};
+
+			enum EPROJECTILE_STATE
+			{
+				PROJECTILE_STATE_EXPIRED,
+				PROJECTILE_STATE_FLYOUT,
+				PROJECTILE_STATE_AT_REST,
+				PROJECTILE_STATE_TO_BE_DETONATED,
+				PROJECTILE_STATE_DETONATION_TO_BE_HANDLED,
+				PROJECTILE_STATE_WAS_DETONATED,
+				PROJECTILE_STATE_TO_BE_REMOVED
+			};
+
+			enum EGRENADE_STATE
+			{
+				GRENADE_STATE_CREATE,
+				GRENADE_STATE_NEWPOS,
+				GRENADE_STATE_DETONATE,
+				GRENADE_STATE_REMOVE
+			};
+
+			enum EZOOM_STATE : char
+			{
+				EZoomState_default = 0,
+				EZoomState_1stperson = 1,
+				EZoomState_unknown = 2,
+				EZoomState_binocs = 3,
+				EZoomState_weapondef_1 = 4
+			};
+
+			enum class ESEAL_TEAMS : i32_t
+			{
+				ETeam_SEALS = 0x40000001,		//	Seal
+				ETeam_TERRORIST = 0x80000100,		//	Terrorist
+				ETeam_TURRET = 0x48000000,		//	Turret
+				ETeam_SPECTATOR = 0x00010000,		//	Spectator
+				ETeam_GHOST = 0x00020000,			//	test
+
+				// CAMPAIGN
+				ETeam_SP_ABLE = 0x84000006,			//	Alpha Team
+				ETeam_SP_BRAVO = 0x8400000A,		//	Bravo Team
+				ETeam_SP_ENEMY_A = 0x40000050,		//	Iron Brother / Iron Leader
+				ETeam_SP_ENEMY_B = 0x40000100,		//	
+				ETeam_SP_ENEMY_C = 0x40000210,		//	
+				ETeam_SP_ENEMY_D = 0x40000410,		//	
+				ETeam_SP_ENEMY_E = 0x40000810,		//	
+				ETeam_SP_ENEMY_F = 0x40001010,		//	
+				ETeam_SP_ENEMY_G = 0x40002010,		//	
+				ETeam_SP_ENEMY_H = 0x40004010,		//	
+				ETeam_SP_ENEMY_I = 0x40021010,		//	
+				ETeam_NONE = 0
+			};
+
+			enum ESEAL_STANCE : char
+			{
+				ESealStance_Stand = 0,
+				ESealStance_Crouch = 1,
+				ESealStance_Prone = 2
+			};
+
+			enum ESEAL_LEAN : char
+			{
+				ESealLean_LEFT,
+				ESealLean_UP,
+				ESealLean_RIGHT,
+				ESealLean_NONE
+			};
+
+			enum ESEALBONES_INDEX : int
+			{
+				ESEALBONES_skel_root = 0,
+				ESEALBONES_aimnodes,
+				ESEALBONES_lfoot,	// left knee
+				ESEALBONES_rfoot,	//	right knee
+				ESEALBONES_lhand,	//	left elbow
+				ESEALBONES_spinelo,
+				ESEALBONES_rhand,	// right elbow
+				ESEALBONES_hips,
+				ESEALBONES_head,	// upper neck
+				ESEALBONES_neck,
+				ESEALBONES_spinehi,
+				ESEALBONES_lthigh,
+				ESEALBONES_rthigh,
+				ESEALBONES_rcalf,	// rhip
+				ESEALBONES_rbicep,
+				ESEALBONES_rforearm,
+				ESEALBONES_lbicep,
+				ESEALBONES_lforearm,
+				ESEALBONES_lscap,
+				ESEALBONES_rscap,
+				ESEALBONES_lshoulder_wgt,
+				ESEALBONES_rshoulder_wgt,
+				ESEALBONES_lcalf,	//	left hip
+				ESEALBONES_ltoe,	//	left heel
+				ESEALBONES_rtoe,	//	right heel
+				ESEALBONES_weapon,
+				ESEALBONES_rifle,
+				ESEALBONES_pistol,
+				ESEALBONES_right_eyeball,
+				ESEALBONES_left_eyeball,
+				ESEALBONES_right_lid,
+				ESEALBONES_left_lid,
+			};
+
+			enum EWEAPONEQUIP_INDEX : __int32
+			{
+				EWeaponIndex_Primary = 0,
+				EWeaponIndex_Secondary = 1,
+				EWeaponIndex_EqSlot1 = 2,
+				EWeaponIndex_EqSlot2 = 3,
+				EWeaponIndex_EqSlot3 = 4
+			};			
+			
+			enum  EWEAPON_ENCUMBRANCE : char
+			{
+				LIGHTLY_ENCUMBERED,
+				MEDIUM_ENCUMBERED,
+				HEAVY_ENCUMBERED,
+				VERY_HEAVILY_ENCUMBERED,
+				NOT_ENCUMBERED,
+				NUM_ECUMBTYPES
+			};
+
+			enum EWEAPON_FIREMODE : __int32
+			{
+				EFireMode_Default = 0,
+				EFireMode_Single = 1,
+				EFireMode_Burst = 2,
+				EFireMode_Auto = 3,
+				EFireMode_Special,
+				NUM_FIREMODES
+			};
+
+			/*
+				Weapons
+
+				NOTE: points to static addresses in the game module defined in SOCOM1_package.h
+			*/
+			enum class EWEAPON : i32_t
+			{
+				EWeapon_EMPTY = 0,
+				EWeapon_M4A1 = WEAPON_M4A1,
+				EWeapon_M4A1_SD = WEAPON_M4A1_SD,
+				EWeapon_M4A1_M203 = WEAPON_M4A1_M203,
+				EWeapon_M16A2 = WEAPON_M16A2,
+				EWeapon_M16A2_M203 = WEAPON_M16A2_M203,
+				EWeapon_552 = WEAPON_552,
+				EWeapon_AK47 = WEAPON_AK47,
+				EWeapon_AKS74 = WEAPON_AKS74,
+				EWeapon_M14 = WEAPON_M14,
+				EWeapon_M63A = WEAPON_M63A,
+				EWeapon_M60E3 = WEAPON_M60E3,
+				EWeapon_PKM = WEAPON_PKM,	//	unknown, not used in SOCOM 1
+				EWeapon_Remington870 = WEAPON_REMINGTON_870,	//	unknown, not used in SOCOM 1
+				EWeapon_MK3_A2 = WEAPON_MK3_A2_SHOTGUN,	//	unknown, not used in SOCOM 1	
+				EWeapon_UZI = WEAPON_9MM_SUB,
+				EWeapon_F90 = WEAPON_F90,
+				EWeapon_HK5 = WEAPON_HK5,
+				EWeapon_HK5_SD = WEAPON_HK5_SD,
+				EWeapon_SR25 = WEAPON_SR25,
+				EWeapon_SR25_SD = WEAPON_SR25_SD,
+				EWeapon_M40A1 = WEAPON_M40A1,
+				EWeapon_M87ELR = WEAPON_M87ELR,
+				EWeapon_M82A1A = WEAPON_M82A1A,
+				EWeapon_M79 = WEAPON_M79,
+				EWeapon_MGL = WEAPON_MGL,
+				EWeapon_M203 = WEAPON_M203,
+				EWeapon_M9 = WEAPON_M9,
+				EWeapon_9MM = WEAPON_9MM_PISTOL,
+				EWeapon_226 = WEAPON_226,
+				EWeapon_F57 = WEAPON_F57,
+				EWeapon_MODEL18 = WEAPON_MODEL_18,
+				EWeapon_DE50 = WEAPON_DE50,
+				EWeapon_MARK23 = WEAPON_MARK_23,
+				EWeapon_MARK23_SD = WEAPON_MARK_23_SD,
+				EWeapon_M67 = WEAPON_M67,
+				EWeapon_HE = WEAPON_HE,
+				EWeapon_SMOKE = WEAPON_SMOKE,
+				EWeapon_FLASHBANG = WEAPON_FLASHBANG,
+				EWeapon_2XAMMO = WEAPON_2X_AMMO,
+				EWeapon_M79_HE = WEAPON_M79_HE,
+				EWeapon_M79_FRAG = WEAPON_M79_FRAG,
+				EWeapon_M79_SMOKE = WEAPON_M79_SMOKE,
+				EWeapon_M203_HE = WEAPON_M203_HE,
+				EWeapon_M203_FRAG = WEAPON_M203_FRAG,
+				EWeapon_M203_SMOKE = WEAPON_M203_SMOKE,
+				EWeapon_C4 = WEAPON_C4,
+				EWeapon_CLAYMORE = WEAPON_CLAYMORE,
+				EWeapon_SATCHEL = WEAPON_SATCHEL,
+				EWeapon_MPBOMB = WEAPON_MPBOMB,	//	unknown, not used in SOCOM 1
+				EWeapon_DETONATOR = WEAPON_DETONATOR,	//	unknown, not used in SOCOM 1
+				EWeapon_BINOCULARS = WEAPON_BINOCULARS,	//	unknown, not used in SOCOM 1
+				EWeapon_KEVLAR_ARMOR = WEAPON_KEVLAR_ARMOR,	//	unknown, not used in SOCOM 1
+				EWeapon_KEVLAR_ARMOR_INSERT = WEAPON_KEVLAR_ARMOR_INSERT,	//	unknown, not used in SOCOM 1
+				EWeapon_ATG_MISSILE = WEAPON_ATG_MISSILE,	//	unknown, not used in SOCOM 1
+				EWeapon_SATCHEL_EXPLOSION = WEAPON_SATCHEL_EXPLOSION,	//	unknown, not used in SOCOM 1
+				EWeapon_LASER_DESIGNATOR = WEAPON_LASER_DESIGNATOR,	//	unknown, not used in SOCOM 1
+			};
+
+			/*
+				Weapon Ammo Types
+
+				NOTE: points to static addresses in the game module defined in SOCOM1_package.h
+			*/
+			enum class EAMMO : i32_t
+			{
+				EWeaponAmmo_EMPTY = 0,
+
+				EWeaponAmmo_M4A1 = AMMO_556x45mm,
+				EWeaponAmmo_M4A1_M203 = AMMO_556x45mm,
+				EWeaponAmmo_M4A1_SD = AMMO_556x45mm,
+				EWeaponAmmo_M16A2 = AMMO_556x45mm,
+				EWeaponAmmo_M16A2_M203 = AMMO_556x45mm,
+				EWeaponAmmo_552 = AMMO_556x45mm,
+				EWeaponAmmo_AK74 = AMMO_545x39mm_SOVIET,
+				EWeaponAmmo_AKS74 = AMMO_545x39mm_SOVIET,
+				EWeaponAmmo_M14 = AMMO_762x51mm,
+
+				EWeaponAmmo_UZI = AMMO_9x19P,
+				EWeaponAmmo_HK5 = AMMO_9x19P,
+				EWeaponAmmo_HK5_SD = AMMO_9x19P,
+				EWeaponAmmo_F90 = AMMO_57x28mm,
+
+				EWeaponAmmo_M60E3 = AMMO_762x39mm_M1943,
+				EWeaponAmmo_M63A = AMMO_556x45mm,
+
+				EWeaponAmmo_SR25 = AMMO_762x51mm,
+				EWeaponAmmo_SR25_SD = AMMO_762x51mm,
+				EWeaponAmmo_M40A1 = AMMO_762x51mm,
+				EWeaponAmmo_M82A1A = AMMO_50BMG,
+				EWeaponAmmo_M87ELR = AMMO_50BMG,
+
+				EWeaponAmmo_9MM = AMMO_9x19P,
+				EWeaponAmmo_P226 = AMMO_9x19P,
+				EWeaponAmmo_M18 = AMMO_9x19P,
+				EWeaponAmmo_F57 = AMMO_57x28mm,
+				EWeaponAmmo_DE50 = AMMO_50AE,
+				EWeaponAmmo_MK23 = AMMO_45ACP,
+				EWeaponAmmo_MK23_SD = AMMO_45ACP,
+
+				EWeaponAmmo_M67 = AMMO_M67,
+				EWeaponAmmo_HE = AMMO_HE,
+				EWeaponAmmo_M141 = AMMO_FLASHBANG,
+				EWeaponAmmo_Smoke = AMMO_SMOKE,
+				EWeaponAmmo_Claymore = AMMO_CLAYMORE,
+				EWeaponAmmo_C4 = AMMO_C4,
+
+				EWeaponAmmo_M79_HE = AMMO_M79_HE,
+				EWeaponAmmo_M79_FRAG = AMMO_M79_FRAG,
+				EWeaponAmmo_M79_SMOKE = AMMO_M79_SMOKE,
+				EWeaponAmmo_M203_HE = AMMO_M203_HE,
+				EWeaponAmmo_M203_FRAG = AMMO_M203_FRAG,
+				EWeaponAmmo_M203_SMOKE = AMMO_M203_SMOKE,
+
+				EWeaponAmmo_Satchel = AMMO_SATCHEL,
+				EWeaponAmmo_LONGRIFLE = AMMO_LONG_RIFLE,	//	unknown, not used in SOCOM 1
+				EWeaponAmmo_SHOTGUN = AMMO_12GUAGE,	//	unknown, not used in SOCOM 1
+				EWeaponAmmo_MP_BOMB = AMMO_MPBOMB,	//	unknown, not used in SOCOM 1
+				EWeaponAmmo_ATG_Missile = AMMO_MISSILE,	//	unknown, not used in SOCOM 1
+				EWeaponAmmo_ExplosiveStuff = AMMO_EXPLOSIVE_STUFF,	//	unknown, not used in SOCOM 1
+
+				//	EWeaponAmmo_2xAmmo = AMMO_2xAmmo,
+			};
+		}
+
+		namespace Structs
+		{
+			struct SSealStats
+			{
+				/* inside CZSealBody */
+				//	int8_t mHeadshots; //0x058C
+				//	char pad_058D[3]; //0x058D
+				//	int8_t mShotsHit; //0x0590
+				//	char pad_0591[3]; //0x0591
+				//	int8_t mShotsFired; //0x0594
+				//	char pad_0595[1]; //0x0595
+				//	int8_t mWasFiredAt; //0x0596
+				//	char pad_0597[5]; //0x0597
+				//	int8_t mWasHit; //0x059C
+				//	char pad_059D[1]; //0x059D
+				//	int8_t mDeaths; //0x059E
+				//	char pad_059F[23]; //0x059F
+				//	int8_t mEquipmentUsed; //0x05B6
+				//	char pad_05B7[1]; //0x05B7
+				//	int8_t mCqCTakedowns; //0x05B8
+				//	char pad_05B9[1]; //0x05B9
+				//	int8_t mPrimaryShotsFired; //0x05BA
+				//	char pad_05BB[1]; //0x05BB
+				//	int8_t mSecondaryShotsFired; //0x05BC
+			};
+
+			struct CZKit
+			{
+				/* inside CZSealBody */
+				//	Vec2 mRecoilPunch; //0x0600
+				//	Vec2 mPrevRecoilPunch; //0x0608
+				//	char pad_0610[8]; //0x0610
+				//	Vec3 mRifleKick; //0x0618
+				//	int32_t mFireRilfeKickState; //0x0624
+				//	int32_t mHeartbeatState; //0x0628
+				//	Vec2 mHeartbeat; //0x062C
+				//	int32_t mCurItemReticule; //0x0634
+				//	Vec2 mScreenOffset; //0x0638
+				//	char pad_0640[132]; //0x0640
+				//	i32_t pWeapons[10]; //0x06C4	CZWeapon*
+				//	char pad_06EC[80]; //0x06EC
+				//	i32_t pAmmoTypes[10]; //0x073C	CZAmmo*
+				//	char pad_0764[120]; //0x0764
+				//	int32_t mPrimaryMags[10]; //0x07DC
+				//	int32_t mSecondaryMags[10]; //0x0804
+				//	int32_t mEqSlot1Ammo; //0x082C
+				//	char pad_0830[36]; //0x0830
+				//	int32_t mEqSlot2Ammo; //0x0854
+				//	char pad_0858[36]; //0x0858
+				//	int32_t mEqSlot3Ammo; //0x087C
+				//	char pad_0880[996]; //0x0880
+				//	int32_t mPrimaryMagIndex; //0x0C64
+				//	int32_t mSecondaryMagIndex; //0x0C68
+				//	char pad_0C6C[112]; //0x0C6C
+				//	int32_t mWeaponFireTypes[2]; //0x0CDC
+				//	char pad_0CE4[276]; //0x0CE4
+				//	int32_t mWeaponFireCount; //0x0DF8
+				//	float mWeaponFireDelta; //0x0DFC
+				//	char pad_0E00[4]; //0x0E00
+				//	int32_t mCurrentWeaponIndex; //0x0E04
+				//	char pad_0E08[4]; //0x0E08
+				//	int32_t mMaxWeaponIndex; //0x0E0C
+				//	i32_t pEntity; //0x0E10	CEntity*
+				//	char pad_0E14[152]; //0x0E14
+			};
+		}
+
+		struct BulletObject
+		{
+			char pad_0000[84];	//0x0000
+			Vec2 bullet;	//0x0054
+			char pad_0060[56];	//0x0060
+		};	//Size: 0x0098
+
+		enum EWeaponSlot : unsigned int
+		{
+			Primary,	// = 0x60C,
+			Secondary,	// = 0x610,
+			EqSlot1,	// = 0x614,
+			EqSlot2,	// = 0x618,
+			EqSlot3,	// = 0x61C,
+		};
+		static const char* AvailSlots[5] = { "Primary", "Secondary", "Equipment 1", "Equipment 2", "Equipment 3" };
+		static const char* TeamNames[10] =
+		{
+			"SEALS",
+			"TERRORISTS",
+			"SPECTATOR",
+			"ABLE",
+			"BRAVO",
+		};
+		static const char* MapNames[50] =
+		{
+			"Blizzard",					//	0			
+			"Blizzard Day",				//	1
+			"Frost Fire",				//	2
+			"Frostfire Day",			//	3
+			"Abandoned",				//	4
+			"Abandoned Day",			//	5
+			"Sand Storm",				//	6
+			"Sandstorm Day",			//	7
+			"Night Stalker",			//	8
+			"Nightstalker Day",			//	9
+			"Desert Glory",				//	10
+			"Desert Glory Night",		//	11
+			"Seeding Chaos",			//	12
+			"Terminal Transaction",		//	13
+			"Upland Assault",			//	14
+			"Urban Sweep",				//	15
+			"Strangle Hold",			//	16
+			"Hydro Electric",			//	17
+			"Guardian Angels",			//	18
+			"Protect and Serve",		//	19
+			"Against the Tide",			//	20
+			"Lockdown",					//	21
+			"Guided Tour",				//	22
+			"Doomsday Delivery",		//	23
+			"",							//	24
+			"Blood Lake",				//	25
+			"Blood Lake Night",			//	26
+			"Death Trap",				//	27
+			"Death Trap Night",			//	28
+			"The Ruins",				//	29
+			"The Ruins Night",			//	30
+			"Enowapi",					//	31
+			"Rat's Nest",				//	32
+			"Rat's Nest Day",			//	33
+			"Fox Hunt",					//	34
+			"Vigilance",				//	35
+			"Bitter Jungle",			//	36
+			"Bitter Jungle Night",		//	37
+			"The Mixer",				//	38
+			"The Mixer Night",			//	39
+			"Fishhook",					//	40
+			"Fish Hook Night"			//	41
+			"Crossroads"				//	42
+			"Crossroads Night"			//	43
+			"Shadow Falls"				//	44
+			"Shadowfalls Day"			//	45
+			"Sujo"						//	46
+			"Chain Reaction"			//	47
+			"Guidanace"					//	48
+			"Requim"					//	49
+		};
+
+		enum EWeapon : i32_t
+		{
+
+			//
+			EWeapon_P_M4A1			= 0xC69920,
+			EWeapon_P_M4A1_M203		= 0xC69E40,
+			EWeapon_P_M4A1_SD		= 0xC69BB0,
+			EWeapon_P_M16A2			= 0xC69690,
+			EWeapon_P_M16A2_M203	= 0xC69400,
+			EWeapon_P_IW80			= 0xC6B030,
+			EWeapon_P_OICW			= 0xC6ADA0,
+			EWeapon_P_HK5			= 0xC6BF90,
+			EWeapon_P_HK5SD			= 0xC6C220,
+			EWeapon_P_HK5K			= 0xC6CC60,
+			EWeapon_P_SMG_9MMSUB	= 0xC6C740,
+			EWeapon_P_F90			= 0xC6C4B0,
+			EWeapon_P_M3_12Gauge	= 0xC68EE0,
+			EWeapon_P_M79			= 0xC71BF0,
+			EWeapon_P_MGL			= 0xC71960,
+			EWeapon_P_M87ELR		= 0xC6D410,
+			EWeapon_P_M82A1A		= 0xC6CEF0,
+
+			//	
+			EWeapon_S_DE50			= 0xC67790,
+			EWeapon_S_M11			= 0xC68480,
+			EWeapon_S_SP10			= 0xC68710,
+			EWeapon_S_Mark23		= 0xC67270,
+			EWeapon_S_Mark23_SD		= 0xC67F60,
+			EWeapon_S_Pistol_226	= 0xC67CD0,
+			EWeapon_S_Pistol_9MM	= 0xC681F0,
+			EWeapon_S_Model18		= 0xC66FE0,
+
+			//	
+			EWeapon_EQ_NONE			= 0xC6E370,
+			EWeapon_EQ_AmmoReserve	= 0xC73AF0,
+			EWeapon_EQ_Frag			= 0xC6EB20,
+			EWeapon_EQ_HE			= 0xC6EDB0,
+			EWeapon_EQ_Smoke		= 0xC6F040,
+			EWeapon_EQ_RedSmoke		= 0xC6F560,
+			EWeapon_EQ_Flashbang	= 0xC6F7F0,
+			EWeapon_EQ_Claymore		= 0xC6FD30,
+			EWeapon_EQ_PMN_Mine		= 0xC6FFC0,
+			EWeapon_EQ_C4			= 0xC70250,
+			EWeapon_EQ_AT4Heat		= 0xC728C0,
+			EWeapon_EQ_AT4Round		= 0xC72B50,
+			EWeapon_EQ_RPG7			= 0xC72DE0,
+			EWeapon_EQ_RPGRound		= 0xC73070,
+			EWeapon_EQ_Satchel		= 0xC6FAA0,
+			EWeapon_EQ_Satchel_a	= 0xC6E0E0,
+			EWeapon_EQ_OICW_Frag	= 0xC71440,
+			EWeapon_EQ_OICW_HE		= 0xC711B0,
+			EWeapon_EQ_OICW_Smoke	= 0xC716D0,
+			EWeapon_EQ_M79_Frag		= 0xC72110,
+			EWeapon_EQ_M79_HE		= 0xC71E80,
+			EWeapon_EQ_M79_Smoke	= 0xC723A0,
+			EWeapon_EQ_MGL_Frag		= 0xC70C90,
+			EWeapon_EQ_MGL_HE		= 0xC70A00,
+			EWeapon_EQ_MGL_Smoke	= 0xC70F20,
+			EWeapon_EQ_M203			= 0xC70770,
+			//	EWeapon_EQ_M203_Frag	= MGL_Frag,
+			//	EWeapon_EQ_M203_HE		= MGL_HE,
+			//	EWeapon_EQ_M203_Smoke	= MGL_Smoke,
+			EWeapon_EQ_ThermalScope = 0xC6E600,
+			EWeapon_EQ_Binoculars	= 0xC6E890,
+
+			EWeapon_EQ_EMPTYSlot = NULL,
+		};
+
+		enum EAmmoType : i32_t
+		{
+			AR_556 = 0xC665E0,			//	5.56x45mm
+			SMG_9mm = 0xC663B0,			//	9x9P
+			PISTOL_45ACP = 0xC664F0,			//	45ACP
+			M67_Round = 0xC667C0,
+			HE_Round = 0xC66810,
+			Flash_Round = 0xC66950,
+			ANM8_Smoke = 0xC66860,
+			C4_Round = 0xC66A90,			//	
+			RPG_Round = 0xC66EF0,			//	
+			M87ELR_Round = 0xC66720,			//	M82A1A Round
+
+			//	???
+			Unknown_Round1 = 0x13001808,		//
+
+		};
+
+		enum EFireType : unsigned __int32
+		{
+			//	Single, Burst, Auto, SecondaryWeapon, EqSlot1, EqSlot2, EqSlot3
+			EFireType_Single = 1,				//	
+			EFireType_Burst = 2,				//	
+			EFireType_Auto = 3,					//	
+			EFireType_SecondaryWeapon = 4,		//	
+			EFireType_EqSlot1 = 5, 				//	
+			EFireType_EqSlot2 = 6,				//	
+			EFireType_EqSlot3 = 7				//	
+		};
+
+		struct CZKit
+		{
+			class CZSeal*						pEntity{ nullptr };
+			EWeapon								Primary;
+			__int32								PrimaryAmmo[10];
+			EAmmoType							PrimaryAmmoType;
+			EFireType							PrimaryFireType;
+			EWeapon								Secondary;
+			__int32								SecondaryAmmo[10];
+			EAmmoType							SecondaryAmmoType;
+			EFireType							SecondaryFireType;
+			EWeapon								EqSlot1;
+			__int32								Eq1Ammo;
+			EAmmoType							Eq1AmmoType;
+			EWeapon								EqSlot2;
+			__int32								Eq2Ammo;
+			EAmmoType							Eq2AmmoType;
+			EWeapon								EqSlot3;
+			__int32								Eq3Ammo;
+			EAmmoType							Eq3AmmoType;
+		
+			void								GiveWeapon(EWeapon, EWeaponSlot, EAmmoType = {}, EFireType = {});
+			void								GiveAmmo(EWeaponSlot, EAmmoType, __int32 count);
+			std::string							ExportLoadoutInfo();
+		};
+
+		enum class ETeam : unsigned int
+		{
+			SEALS = 0x40000001,			//	Seal
+			TERRORIST = 0x80000100,			//	Terrorist
+			TURRET = 0x48000000,			//	Turret
+			SPECTATOR = 0x00010000,			//	Spectator
+
+			// CAMPAIGN
+			SP_ABLE = 0x84000006,			//	Alpha Team
+			SP_BRAVO = 0x8400000A,			//	Bravo Team
+			SP_ENEMY_A = 0x40000050,			//	Iron Brother / Iron Leader
+			SP_ENEMY_B = 0x40000100,			//	
+			SP_ENEMY_C = 0x40000210,			//	
+			SP_ENEMY_D = 0x40000410,			//	
+			SP_ENEMY_E = 0x40000810,			//	
+			SP_ENEMY_F = 0x40001010,			//	
+			SP_ENEMY_G = 0x40002010,			//	
+			SP_ENEMY_H = 0x40004010,			//	
+			SP_ENEMY_I = 0x40021010,			//	
+			NONE = 0
+		};
+
+		enum class ECameraViewType
+		{
+			ThirdPersonCamera = 0x100,
+			FirstPersonCamera = 0x1,
+			EquipmentCameraView = 0x103,
+			Scope_8 = 0x305,
+			Scope_16 = 0x506,
+			Thermal = 0x10102,
+		};
+
+		enum EMaps : unsigned int
+		{
+			MP1 = 0,		//	0
+			MP26,			//	1
+			MP2,			//	2
+			MP27,			//	3
+			MP5,			//	4
+			MP21,			//	5
+			MP73,			//	6
+			MP89,			//	7
+			MP7,			//	8
+			MP29,			//	9
+			MP6,			//	10
+			MP28,			//	11
+			M51,			//	12
+			M52,			//	13
+			M53,			//	14
+			M61,			//	15
+			M62,			//	16
+			M63,			//	17
+			M71,			//	18
+			M72,			//	19
+			M73,			//	20
+			M81,			//	21
+			M82,			//	22
+			MP_NONE,		//	23
+			MP10,			//	24
+			MP32,			//	25
+			MP11,			//	26
+			MP33,			//	27
+			MP12,			//	28
+			MP34,			//	29
+			MP62,			//	30
+			MP8,			//	31
+			MP30,			//	32
+			MP53,			//	33
+			MP51,			//	34
+			MP9,			//	35
+			MP31,			//	36
+			MP52,			//	37
+			MP25,			//	38
+			MP71,			//	39
+			MP23,			//	40
+			MP72,			//	41
+			MP24,			//	42
+			MP64,			//	43
+			MP80,			//	44
+			MP61,			//	45
+			MP81,			//	46
+			MP82,			//	47
+			MP83,			//	48
+		};
+
+		template<typename Z>
+		struct ZArrayIterator
+		{
+		private:
+			__int32 _next;		//	might be start	??
+			__int32 _prev;		//	first object in the array will point to the start.
+			__int32 _data;		//	Z
+
+		public:
+
+			ZArrayIterator()
+			{
+				_next = 0;
+				_prev = 0;
+				_data = 0;
+			}
+
+			ZArrayIterator(__int32 next, __int32 prev, __int32 data)
+			{
+				_next = next;
+				_prev = prev;
+				_data = data;
+			}
+
+			Z Data() const { return reinterpret_cast<Z>(PS2Memory::GetEEBase() + _data); }
+			ZArrayIterator<Z> Next() const { return PS2Memory::ReadEE<ZArrayIterator<Z>>(_next); }
+			ZArrayIterator<Z> Prev() const { return PS2Memory::ReadEE<ZArrayIterator<Z>>(_prev); }
+		};
+
+		template<typename Z>
+		struct ZArray
+		{
+		private:
+			__int32 _count;
+			__int32 _begin;
+			__int32 _end;
+
+		public:
+			ZArray()
+			{
+				_count = 0;
+				_begin = 0;
+				_end = 0;
+			}
+
+			ZArray(__int32 count, __int32 begin, __int32 end)
+			{
+				_count = count;
+				_begin = begin;
+				_end = end;
+			}
+
+			int Count() const { return _count; }
+			bool IsValid() const { return false; }	//	check if count > 0 && if _begin & _end are <= 0
+			ZArrayIterator<Z> GetIterator() const
+			{
+				return PS2Memory::ReadEE<ZArrayIterator<Z>>(_begin);
+			}
+
+			std::vector<Z> Data() const
+			{
+				std::vector<Z> result;
+
+				if (_count > 0)
+				{
+					ZArrayIterator<Z> it = GetIterator();	/* get first item */
+					ZArrayIterator<Z> end = it.Prev();		/* get last item */
+
+					do
+					{
+						/* get the data */
+						Z data = it.Data();
+
+						/* populate result with data */
+						result.push_back(data);
+
+						/* move on to the next item */
+						it = it.Next();
+
+					} while (it.Data() != end.Data());	/* loop until the end */
+				}
+
+				return result;
+			}
+		};
+
+	}
+}
+#pragma pack(pop)

--- a/modules/SOCOM 2 U.S Navy Seals/SOCOM2_package.cpp
+++ b/modules/SOCOM 2 U.S Navy Seals/SOCOM2_package.cpp
@@ -1,0 +1,1406 @@
+#pragma once
+#include "SOCOM2_package.h"
+
+/**
+ * Name: SOCOM 2
+ * Platform: PlayStation 2
+ * PCSX2 Version: 1.7 beta
+ * Author: NightFyre
+*/
+
+#pragma pack(push, 0x01)
+namespace PlayStation2::SOCOM2
+{
+
+	//----------------------------------------------------------------------------------------------------
+	//										GLOBALS
+	//-----------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------
+	std::string GetWeaponName(i32_t Weapon)
+	{
+		switch (Weapon)
+		{
+			//	Primaries
+		case EWeapon_P_M4A1:				return "M4A1";
+		case EWeapon_P_M4A1_M203:			return "M4A1-M203";
+		case EWeapon_P_M4A1_SD:				return "M4A1 SD";
+		case EWeapon_P_M16A2:				return "M16A2";
+		case EWeapon_P_M16A2_M203:			return "M16A2-M203";
+		case EWeapon_P_IW80:				return "IW-80 A2";
+		case EWeapon_P_OICW:				return "OICW";
+		case EWeapon_P_HK5:					return "HK5";
+		case EWeapon_P_HK5SD:				return "HK5SD";
+		case EWeapon_P_HK5K:				return "HK5K";
+		case EWeapon_P_SMG_9MMSUB:			return "9mm SUB";
+		case EWeapon_P_F90:					return "F90";
+		case EWeapon_P_M3_12Gauge:			return "M3 12-Guage";
+		case EWeapon_P_M79:					return "M79";
+		case EWeapon_P_MGL:					return "MGL";
+		case EWeapon_P_M87ELR:				return "M87ELR";
+		case EWeapon_P_M82A1A:				return "M82A1A";
+
+			// Secondaries
+		case EWeapon_S_DE50:				return "DE .50";
+		case EWeapon_S_M11:					return "M11";
+		case EWeapon_S_SP10:				return "SP-10";
+		case EWeapon_S_Mark23:				return "Mark23";
+		case EWeapon_S_Mark23_SD:			return "Mark23SD";
+		case EWeapon_S_Pistol_226:			return "226";
+		case EWeapon_S_Pistol_9MM:			return "9mm Pistol";
+		case EWeapon_S_Model18:				return "Model 18";
+
+			// Equipment
+		case EWeapon_EQ_NONE:				return "NONE";
+		case EWeapon_EQ_AmmoReserve:		return "2x Ammo";
+		case EWeapon_EQ_Frag:				return "Frag";
+		case EWeapon_EQ_HE:					return "HE";
+		case EWeapon_EQ_Smoke:				return "AN-M8";
+		case EWeapon_EQ_RedSmoke:			return "RED AN-M8";
+		case EWeapon_EQ_Flashbang:			return "Flashbang";
+		case EWeapon_EQ_Claymore:			return "Claymore";
+		case EWeapon_EQ_PMN_Mine:			return "PMN";
+		case EWeapon_EQ_AT4Heat:			return "AT4 Heat";
+		case EWeapon_EQ_AT4Round:			return "AT4 Round";
+		case EWeapon_EQ_RPG7:				return "RPG-7";
+		case EWeapon_EQ_RPGRound:			return "RPG-7 Round";
+		case EWeapon_EQ_Satchel:			return "Satchel";
+		case EWeapon_EQ_Satchel_a:			return "Satchel A";
+		case EWeapon_EQ_OICW_Frag:			return "OICW Frag";
+		case EWeapon_EQ_OICW_HE:			return "OICW HE";
+		case EWeapon_EQ_OICW_Smoke:			return "OICW Smoke";
+		case EWeapon_EQ_M79_Frag:			return "M79 Frag";
+		case EWeapon_EQ_M79_HE:				return "M79 HE";
+		case EWeapon_EQ_M79_Smoke:			return "M79 Smoke";
+		case EWeapon_EQ_MGL_Frag:			return "MGL Frag";
+		case EWeapon_EQ_MGL_HE:				return "MGL HE";
+		case EWeapon_EQ_MGL_Smoke:			return "MGL Smoke";
+		case EWeapon_EQ_ThermalScope:		return "Thermal Scope";
+		case EWeapon_EQ_Binoculars:			return "Binoculars";
+		}
+
+		//	char data[0x56];
+		//	const char* data2 = "%08X";
+		//	sprintf_s(data, data2, Weapon);
+		return std::to_string(Weapon);
+	}
+
+
+	//---------------------------------------------------------------------------------------------------
+	std::string GetAmmoTypeName(i32_t AmmoType)
+	{
+		switch (AmmoType)
+		{
+		case (AR_556):			return "5.56x45";
+		case (SMG_9mm):			return "9x19";
+		case (PISTOL_45ACP):	return ".45 ACP";
+		case (M67_Round):		return "M67 FRAG";
+		case (HE_Round):		return "HE FRAG";
+		case (Flash_Round):		return "FLASHBANG";
+		case (ANM8_Smoke):		return "AN-M8 SMOKE";
+		case (C4_Round):		return "C4";
+		case (RPG_Round):		return "RPG";
+		case (M87ELR_Round):	return "";
+		case (Unknown_Round1):	return "";
+		}
+
+		//	char data[0x56];
+		//	const char* data2 = "%08X";
+		//	sprintf_s(data, data2, AmmoType);
+		return std::to_string(AmmoType);
+	}
+
+	std::string GetTeamNameByID(int teamid)
+	{
+		switch ((ETeam)teamid)
+		{
+		case ETeam::SEALS:			return	"SEAL";
+		case ETeam::TERRORIST:		return	"TERRORIST";
+		case ETeam::SPECTATOR:		return	"SPECTATOR";
+		case ETeam::SP_ABLE:		return	"SEALS - ABLE TEAM";
+		case ETeam::SP_BRAVO:		return	"SEALS - BRAVO TEAM";
+		default:					return	"AI";
+		}
+
+		return "N/A";
+	}
+
+	//	bool GetBoneNameByIndex(int index, std::string& outResult)
+	//	{
+	//		return false;
+	//	}
+	//	
+	//	bool GetBoneTransformByIndex(int index, Mat4x4& outResult)
+	//	{
+	//		return false;
+	//	}
+
+	//----------------------------------------------------------------------------------------------------
+	//										DUMPER
+	//-----------------------------------------------------------------------------------
+	namespace Dumper
+	{
+		void Dumper::DumpWeaponStats()
+		{
+			/* Get EEMem Base Address */
+			const __int64& _EE = PS2Memory::GetEEBase();
+			if (!_EE)
+				return;
+
+			/* get weapon pointers */
+			//	ZListWeapons* weaponMan = reinterpret_cast<ZListWeapons*>(_EE + Offsets::p_WeaponManager);
+			//	if (!weaponMan)
+			//		return;
+
+			/* read into local process memory */
+			ZListWeapons weaponMan = PS2Memory::ReadEE<ZListWeapons>(Offsets::p_WeaponManager);
+
+			int szArrays[] = { 5, 6, 43, 25, 7 };
+
+			for (int i = 0; i < 5; i++)	/* iterate weapon lists in ZListWeapons */
+			{
+				for (int j = 0; j < szArrays[i]; j++)	/* iterate through size of each array */
+				{
+					CZWeapon* weapon = nullptr;
+					switch (i)
+					{
+					case 0: weapon = &weaponMan.mList1[j]; break;
+					case 1: weapon = &weaponMan.mList2[j]; break;
+					case 2: weapon = &weaponMan.mList3[j]; break;
+					case 3: weapon = &weaponMan.mList4[j]; break;
+					case 4: weapon = &weaponMan.mList5[j]; break;
+					}
+					if (!weapon || weapon->vfTable != 0x434D30)	/* */
+						continue;
+
+					/* get names */
+					std::string name = (char*)PS2Memory::GetEEAddr(weapon->pDisplayName);
+					std::string name_internal = (char*)PS2Memory::GetEEAddr(weapon->pName);
+					std::string name_icon = (char*)PS2Memory::GetEEAddr(weapon->pIconName);
+					std::string name_bullet = (char*)PS2Memory::GetEEAddr(weapon->pBulletImpactName);
+					std::string name_ammo = "N/A";
+
+					/* Get Ammo Type */
+					int szAmmo_types = weapon->mLegalAmmoList.Count();	/* log count of ammo types */
+					std::vector<CZAmmo*> ammo = weapon->mLegalAmmoList.Data();
+					if (szAmmo_types > 0 && ammo.size() > 0)
+					{
+						/* grab names from first ammo type index */
+						name_ammo = (char*)PS2Memory::GetEEAddr(ammo[0]->pDisplayName);
+					}
+
+					/* |DisplayName| Internal Name| Icon| BulletMark| MaxHitDistance| MagazineAmmoAmount| FireRate| DamageModifier| Recoil| RecoilResetDelay| Bloom| BloomResetTimer| WeaponId| */
+					//	Console::LogMsg("|%s| %s| %s| %s| %s| %.0f| %d| %.2f| %.2f| %.0f| %.0f| %.0f| %.0f| 0x%08X\n", 
+					//		name.c_str(),					//	0x08	| char*
+					//		name_internal.c_str(), 			//	0x04	| char*
+					//		name_icon.c_str(),				//	0x14	| char*
+					//		name_bullet.c_str(),			//	0x20	| char*
+					//		name_ammo.c_str(),				//	0xC4	| ZArray<CZAmmo*>
+					//		weapon->mMaxRange,				//	0x3C	| float
+					//		weapon->szMag,					//	0x28	| __int32
+					//		weapon->mFireWaitTime,			//	0x50	| float
+					//		weapon->mDamageModifier,		//	0x64	| float
+					//		weapon->mRecoil,				//	0x100	| float
+					//		weapon->mRecoilResetDelay,		//	0xFC	| float
+					//		weapon->mBloom,					//	0xF8	| float
+					//		weapon->mBloomResetTimer,		//	0x130	| float
+					//		weapon->mID						//	0x7C	| __int32
+					//	);
+
+					/* dump pointers */
+					if (ammo.size() > 0)
+						Console::LogMsg("%s: 0x%08X\n-\t%s: 0x%08X\n\n", name.c_str(), (weapon - _EE), name_ammo.c_str(), (ammo[0] - _EE));
+					else
+						Console::LogMsg("%s: 0x%08X\n\n", name.c_str(), (weapon - _EE));
+				}
+			}
+		}
+
+		void Dumper::DumpAmmoStats()
+		{
+			/* Get EEMem Base Address */
+			const __int64& _EE = PS2Memory::GetEEBase();
+			if (!_EE)
+				return;
+
+			/* Get Ammo Array Base Address "9x19mm" */
+			__int64 pAmmoMan = _EE + Offsets::p_AmmoManager;
+			if (!pAmmoMan)
+				return;
+
+			/* iterate through size of array */
+			for (int i = 0; i < 39; i++)
+			{
+				/* get ammo object reference */
+				CZAmmo* pAmmo = reinterpret_cast<CZAmmo*>(pAmmoMan + (i * sizeof(CZAmmo)));
+				if (!pAmmo)
+					continue;
+
+				/* get names */
+				std::string name = (char*)PS2Memory::GetEEAddr(pAmmo->pDisplayName);
+				std::string name_internal = (char*)PS2Memory::GetEEAddr(pAmmo->pName);
+
+				/* |DisplayName| Internal Name| ImpactDamage| Stun| Piercing| ExplosionDamage| ExplosionRadius| AmmoId| */
+				//	Console::LogMsg("|%s| %s| %.0f| %.0f| %.0f| %.0f| %.0f| 0x%08X\n", 
+				//		name.c_str(),					//	0x08	| char*
+				//		name_internal.c_str(), 			//	0x04	| char*
+				//		pAmmo->mImpactDmg,				//	0x0C	| float
+				//		pAmmo->mStun,					//	0x10	| float
+				//		pAmmo->mPiercing,				//	0x14	| float
+				//		pAmmo->mExplosionDmg,			//	0x18	| float
+				//		pAmmo->mExplosionRadius,		//	0x1C	| float
+				//		pAmmo->mID						//	0x30	| __int32
+				//	);
+
+				/* dump pointers */
+				Console::LogMsg("%s: 0x%08X\n", name.c_str(), (pAmmo - _EE));
+			}
+		}
+
+		void Dumper::DumpBoneNames()
+		{
+			std::vector<std::string> partNames;	//	bone names
+
+			/* get local seal object */
+			CZSealBody* pSealBody = CZSealBody::GetDefaultInstance();
+			if (!pSealBody)
+				return;
+
+			/* get body part array */
+			static const int szBodyParts = 0x20;
+			for (int i = 0; i < szBodyParts; i++)
+			{
+				/* get body part offset */
+				i32_t iBodyPart = pSealBody->mSkeleton[i];
+				if (iBodyPart == 0)
+					continue; // skip null body parts
+
+				/* get body part class instance */
+				auto pBodyPart = (CZBodyPart*)PS2Memory::GetEEAddr(iBodyPart);
+				if (!pBodyPart)
+					continue; // skip null body part pointers
+
+				/* get bone name */
+				std::string partName = pBodyPart->GetName();
+				if (partName.empty())
+					continue; // skip empty names
+			
+				partNames.push_back(partName);	// add bone name to list
+			}
+
+			/* log bone names */
+			Console::LogMsg("[+]Dumping Bone Names\n");
+			DWORD index = -1;
+			for (auto& name : partNames)
+			{
+				index++;
+			
+				Console::LogMsg("[%d] %s\n", index, name.c_str());
+			}
+			Console::LogMsg("[+] finished dumping bones with count %d\n", partNames.size());
+
+			/* create enum list for bones */
+			//	Console::LogMsg("enum ESEALBONES_INDEX : int\n{\n");
+			//	for (auto& name : partNames)
+			//		Console::LogMsg("\tESEALBONES_%s,\n", name.c_str());
+			//	Console::LogMsg("};\n\n");
+		}
+
+		void DumpBoneHierarchy()
+		{
+			/*
+
+				std::vector<std::pair<std::pair<std::string, Vec3> , std::vector<std::string, Vec3>>>
+
+				[0]bone_name -> bone_origin
+				[1]bone_name -> bone_origin
+				- [0]parent_bone_name -> parent_bone_origin
+				- - [1]parent_bone_name -> parent_bone_origin
+				- - - [2]parent_bone_name -> parent_bone_origin
+				- - - - [3]parent_bone_name -> parent_bone_origin
+				[2]bone_name -> bone_origin
+				- [0]parent_bone_name -> parent_bone_origin
+				- - [1]parent_bone_name -> parent_bone_origin
+				- - - [2]parent_bone_name -> parent_bone_origin
+				[3]bone_name -> bone_origin
+
+
+
+
+			*/
+
+			std::vector<Mat4x4> vBoneMatrices;	//	bone matrices
+			std::vector< std::pair <
+				std::pair< std::string, Vec3 >, 	//	bone_name -> bone_origin
+				std::vector< std::pair< std::string, Vec3 > >	// parent bones array of names and origins
+			>	// ~std::pair
+			> vParts;	//	bone_name -> bone_origin , 
+			//	std::pair<std::vector<std::pair<std::string, Vec3>>, std::vector<std::pair<std::string, Vec3>>> parts;	// pair of part name and origins
+			/* get local seal object */
+			CZSealBody* pSealBody = CZSealBody::GetDefaultInstance();
+			if (!pSealBody)
+				return;
+
+			Vec3 origin = pSealBody->GetOrigin();	// get seal body origin
+			Console::LogMsg("Dumping Bone Names & Positions for Seal Body @ origin { %.2f, %.2f, %.2f }\n", origin.x, origin.y, origin.z);
+
+			/* get body part array */
+			static const int szBodyParts = 0x20;
+			for (int i = 0; i < szBodyParts; i++)
+			{
+				/* define parts storage container  */
+				std::pair<
+					std::pair< std::string, Vec3 >,		// pair of part name and origin
+					std::vector< std::pair< std::string, Vec3 > >	// parent bones array of names and origins
+				> parts;
+
+				/* get body part offset */
+				i32_t iBodyPart = pSealBody->mSkeleton[i];
+				if (iBodyPart == 0)
+					continue; // skip null body parts
+
+				/* get body part class instance */
+				auto pBodyPart = (CZBodyPart*)PS2Memory::GetEEAddr(iBodyPart);
+				if (!pBodyPart)
+					continue; // skip null body part pointers
+
+				/* get bone name */
+				std::string partName = pBodyPart->GetName();
+				if (partName.empty())
+					continue; // skip empty names
+
+				/* set first pair in parts storage container */
+				parts.first =
+				{
+					partName,				// part name
+					pBodyPart->GetOrigin()	// part origin
+				};
+
+				Mat4x4 boneMatrix;	// create bone matrix
+				pBodyPart->GetLocalTM(&boneMatrix);
+				vBoneMatrices.push_back(boneMatrix);
+
+				/* get parent bones */
+				bool bFoundParents{ false };
+				do
+				{
+					/* get parent part */
+					pBodyPart = pBodyPart->GetParent();
+					if (!pBodyPart)
+					{
+						bFoundParents = true; // no parent found, exit loop
+						break;
+					}
+
+					/* get parent name */
+
+					parts.second.push_back(
+						{
+							pBodyPart->GetName(),		// get parent name
+							pBodyPart->GetOrigin()		// get parent origin
+						}
+					);	// add parent data to list
+
+				} while (!bFoundParents);
+
+				// add to main parts list
+				vParts.push_back(parts);
+			}
+
+			DWORD boneIndex = -1;
+			for (auto& part : vParts)
+			{
+				/*
+					std::pair <
+						std::pair< std::string, Vec3 >, 	//	bone_name -> bone_origin
+						std::vector< std::pair< std::string, Vec3 > >
+				*/
+
+				/*
+				* part.first = base bone -> string, Vec3
+					- part.first = base bone name
+					- part.second = base bone origin
+
+				* part.second = parent bone std::vector<string, Vec3>
+				*/
+				boneIndex++;
+
+				Console::LogMsg(
+					"[%d] %s\t-> localOrigin: { x: %.2f,\ty: %.2f,\tz: %.2f }\n",
+					boneIndex,
+					part.first.first.c_str(),
+					part.first.second.x, part.first.second.y, part.first.second.z
+				);
+
+				DWORD parentIndex = -1;
+				for (auto& parentPart : part.second)
+				{
+					parentIndex++;
+					Console::LogMsg(
+						"- parent[%d]: %s\t-> localOrigin: { x: %.2f,\ty: %.2f,\tz: %.2f }\n",
+						parentIndex,
+						parentPart.first.c_str(),
+						parentPart.second.x, parentPart.second.y, parentPart.second.z
+					);
+				}
+
+				Console::LogMsg(
+					"- BoneMatrix:\n"
+					"\t- [x]: { x: %.2f,\ty: %.2f,\tz: %.2f, w:\t%.2f }\n"
+					"\t- [y]: { x: %.2f,\ty: %.2f,\tz: %.2f, w:\t%.2f }\n"
+					"\t- [z]: { x: %.2f,\ty: %.2f,\tz: %.2f, w:\t%.2f }\n"
+					"\t- [w]: { x: %.2f,\ty: %.2f,\tz: %.2f, w:\t%.2f }\n",
+					vBoneMatrices[boneIndex].m[0][0], vBoneMatrices[boneIndex].m[0][1], vBoneMatrices[boneIndex].m[0][2], vBoneMatrices[boneIndex].m[0][3],
+					vBoneMatrices[boneIndex].m[1][0], vBoneMatrices[boneIndex].m[1][1], vBoneMatrices[boneIndex].m[1][2], vBoneMatrices[boneIndex].m[1][3],
+					vBoneMatrices[boneIndex].m[2][0], vBoneMatrices[boneIndex].m[2][1], vBoneMatrices[boneIndex].m[2][2], vBoneMatrices[boneIndex].m[2][3],
+					vBoneMatrices[boneIndex].m[3][0], vBoneMatrices[boneIndex].m[3][1], vBoneMatrices[boneIndex].m[3][2], vBoneMatrices[boneIndex].m[3][3]
+				);
+
+
+				Mat4x4 boneWorldMatrix;
+				if (pSealBody->GetBoneWorldTM(boneIndex, &boneWorldMatrix))
+				{
+					Console::LogMsg(
+						"- BoneWorldMatrix:\n"
+						"\t- [x]: { x: %.2f,\ty: %.2f,\tz: %.2f, w:\t%.2f }\n"
+						"\t- [y]: { x: %.2f,\ty: %.2f,\tz: %.2f, w:\t%.2f }\n"
+						"\t- [z]: { x: %.2f,\ty: %.2f,\tz: %.2f, w:\t%.2f }\n"
+						"\t- [w]: { x: %.2f,\ty: %.2f,\tz: %.2f, w:\t%.2f }\n",
+						boneWorldMatrix.m[0][0], boneWorldMatrix.m[0][1], boneWorldMatrix.m[0][2], boneWorldMatrix.m[0][3],
+						boneWorldMatrix.m[1][0], boneWorldMatrix.m[1][1], boneWorldMatrix.m[1][2], boneWorldMatrix.m[1][3],
+						boneWorldMatrix.m[2][0], boneWorldMatrix.m[2][1], boneWorldMatrix.m[2][2], boneWorldMatrix.m[2][3],
+						boneWorldMatrix.m[3][0], boneWorldMatrix.m[3][1], boneWorldMatrix.m[3][2], boneWorldMatrix.m[3][3]
+					);
+				}
+			}
+		}
+	
+	}
+
+	//----------------------------------------------------------------------------------------------------
+	//										OFFSETS
+	//-----------------------------------------------------------------------------------
+	/*
+		//---------------------------------------------------------------------------------------------------
+		std::string Offsets::LogData()
+		{
+
+			char data[0x1024];
+			const char* data2 = "%llX	0x%08X	:	%s\n";
+			std::string result;
+			for (int i = 0; i < OffsetArray.size(); i++) {
+				sprintf_s(data, data2, PS2Memory::GetEEAddr(OffsetArray[i]),PS2Memory::ReadLong<int>(PS2Memory::GetEEAddr(OffsetArray[i])), names[i].c_str());
+				result += data;
+			}
+			return (result += "\n");
+		}
+
+		//---------------------------------------------------------------------------------------------------
+		std::vector<class CPlayer*> Offsets::GetEntityArray()
+		{
+			return CZMatchData::GetPlayers();
+		}
+	*/
+
+
+
+	//----------------------------------------------------------------------------------------------------
+	//										STRUCTS
+	//-----------------------------------------------------------------------------------
+
+#pragma region // STRUCTS
+
+#pragma endregion
+
+	//----------------------------------------------------------------------------------------------------
+	//										CLASSES
+	//-----------------------------------------------------------------------------------
+
+#pragma region // CLASSES
+
+	//----------------------------------------------------------------------------------------------------
+	//										CNode
+	std::string CNode::GetName() { return (char*)PS2Memory::GetEEAddr(this->pName); }
+	CNode* CNode::GetParent() { return (CNode*)PS2Memory::GetEEAddr(this->pParent); }
+	CNodeEx* CNode::GetNodeExObject() { return (CNodeEx*)PS2Memory::GetEEAddr(this->pNodeEx); }
+	CModel* CNode::GetModelObject() { return (CModel*)PS2Memory::GetEEAddr(this->pModel); }
+	CEntity* CNode::GetEntityObject() { CNodeEx* pNode = GetNodeExObject(); return pNode == nullptr ? nullptr : pNode->GetEntity(); }
+	bool CNode::IsVisible() { return this->mOpacity > 0.0f; }
+	void CNode::SetVisibility(float opacity) { this->mOpacity = opacity; }
+	Vec3 CNode::GetWorldPos() const { return Vec3(this->mMatrix.m[3][0], this->mMatrix.m[3][1], this->mMatrix.m[3][2]); }
+	void CNode::SetWorldPos(const Vec3& newPos) {}
+	Mat4x4 CNode::GetWorldTM() { return this->mMatrix; }
+	void CNode::SetWorldTM(const Mat4x4& newTM) { this->mMatrix = newTM; }
+	AABB CNode::GetLocalBounds() const { return this->mAABB; }
+	AABB CNode::GetWorldBounds() const { return this->mAABB + GetWorldPos(); }
+	Vec3 CNode::GetRightVector() const { return Vec3(this->mMatrix.m[0][0], this->mMatrix.m[0][1], this->mMatrix.m[0][2]); }
+	Vec3 CNode::GetUpVector() const { return Vec3(this->mMatrix.m[1][0], this->mMatrix.m[1][1], this->mMatrix.m[1][2]); }
+	Vec3 CNode::GetForwardVector() const { return Vec3(this->mMatrix.m[2][0], this->mMatrix.m[2][1], this->mMatrix.m[2][2]); }
+	float CNode::GetYawAngleRadians() const { return atan2(-this->mMatrix.m[2][0], this->mMatrix.m[2][2]); }
+	float CNode::GetYawAngleDegrees() const { float yawAngle = GetYawAngleDegrees() * (180.f / M_PI); return yawAngle < 0.f ? yawAngle : yawAngle + 360.f; }
+
+
+	//----------------------------------------------------------------------------------------------------
+	//										CNodeEx
+	CEntity* CNodeEx::GetEntity() { return (CEntity*)PS2Memory::GetEEAddr(this->pEntity); }
+
+	//----------------------------------------------------------------------------------------------------
+	//										CModel
+
+
+	//----------------------------------------------------------------------------------------------------
+	//										CTarget
+	CEntity* CTarget::GetEntity() { return (CEntity*)PS2Memory::GetEEAddr(this->pEntity); }
+
+	bool CTarget::GetOrigin(Vec3* out)
+	{
+		CEntity* pEntity = GetEntity();
+		if (!pEntity)
+			return false;
+
+		*out = pEntity->GetOrigin();
+
+		return true;
+	}
+
+	float CTarget::GetDistance() const { return this->mDistance; }
+	bool CTarget::IsVisible() const { return this->mVisiblity >= 2.0f; }
+	bool CTarget::WasRecentlyVisible() const { return this->mVisiblity != 2.0f && this->mVisiblity >= 1.7f; }
+
+
+	//----------------------------------------------------------------------------------------------------
+	//										CAppCamera
+	CAppCamera* CAppCamera::GetDefaultInstance()
+	{
+		if (!Offsets::o_LocalCAppCamera)
+			return nullptr;
+
+
+		return PS2Memory::GetPtrShort<CAppCamera*>(Offsets::o_LocalCAppCamera);
+	}
+
+	CZCamera* CAppCamera::GetCameraObject() { return this->pCamera == 0 ? nullptr : (CZCamera*)PS2Memory::GetEEAddr(this->pCamera); }
+
+	CEntity* CAppCamera::GetAttachedEntity() { return this->pAttachedEntity == 0 ? nullptr : (CEntity*)PS2Memory::GetEEAddr(this->pAttachedEntity); }
+
+
+	//----------------------------------------------------------------------------------------------------
+	//										CEntity
+	bool CEntity::IsValid()
+	{
+		//	if (this->vfTable != 0x434D30) // CEntity vtable
+		//		return false;
+		if (this->mEntityType == Enums::EENTITY_TYPE::ENT_TYPE_UNKNOWN)
+			return false;
+		if (this->pName <= 0 || this->pNode <= 0)
+			return false;
+		if (this->mTeamID == Enums::ESEAL_TEAMS::ETeam_NONE)
+			return false;
+		return true;
+	}
+
+	Enums::EENTITY_TYPE CEntity::GetEntityType() { return this->mEntityType; }
+	Vec3 CEntity::GetOrigin() { return this->mOrigin; }
+	Mat4x4 CEntity::GetTM() { return this->mMatrix; }
+	Enums::ESEAL_TEAMS CEntity::GetTeamID() { return this->mTeamID; }
+	std::string CEntity::GetName() { if (!pName) return ""; return (char*)PS2Memory::GetEEAddr(this->pName); }
+	CNode* CEntity::GetNodeObject() { if (!pNode) return nullptr; return (CNode*)PS2Memory::GetEEAddr(this->pNode); }
+	
+	bool CEntity::GetTargets(std::vector<CTarget*> out)
+	{ 
+		if (!this->IsValid() || this->mTargetCount <= 0 || this->mMaxTargetCount <= 0)
+			return false;
+
+		unsigned __int64 pTargetArray = PS2Memory::GetEEAddr(this->pTargetArray);
+		if (!pTargetArray)
+			return false;	//	no target array, cannot check visibility
+
+		out.clear();	//	clear output vector
+		for (int i = 0; i < this->mTargetCount; i++)
+		{
+			CTarget* pTarget = (CTarget*)(pTargetArray + (i * sizeof(CTarget)));
+			if (!pTarget)
+				continue;
+
+			out.push_back(pTarget);	//	add target to output vector
+		}
+
+		return out.size() > 0;	// targets found
+	}
+
+	bool CEntity::GetWorldTM(Mat4x4* out) 
+	{ 
+		CNode* pNode = GetNodeObject();
+		if (!pNode)
+			return false;
+
+		*out = pNode->GetWorldTM();
+
+		return true;
+	}
+
+	bool CEntity::SetWorldPos(const Vec3& newPos)
+	{
+		CNode* pNode = GetNodeObject();
+		if (!pNode)
+			return false;
+
+		pNode->SetWorldPos(newPos);
+
+		return true;
+	}
+
+	bool CEntity::GetWorldPos(Vec3* out)
+	{
+		CNode* pNode = GetNodeObject();
+		if (!pNode)
+			return false;
+
+		*out = pNode->GetWorldPos();
+
+		return true;
+	}
+
+	bool CEntity::GetLocalBounds(AABB* out)
+	{
+		CNode* pNode = GetNodeObject();
+		if (!pNode)
+			return false;
+
+		*out = pNode->GetLocalBounds();
+
+		return true;
+	}
+
+	bool CEntity::GetWorldBounds(AABB* out)
+	{
+		CNode* pNode = GetNodeObject();
+		if (!pNode)
+			return false;
+
+		*out = pNode->GetWorldBounds();
+
+		return true;
+	}
+
+	bool CEntity::GetForwardVector(Vec3* out)
+	{
+		CNode* pNode = GetNodeObject();
+		if (!pNode)
+			return false;
+
+		*out = pNode->GetForwardVector();
+
+		return true;
+	}
+
+	bool CEntity::GetRightVector(Vec3* out)
+	{
+		CNode* pNode = GetNodeObject();
+		if (!pNode)
+			return false;
+
+		*out = pNode->GetRightVector();
+
+		return true;
+	}
+
+	bool CEntity::GetUpVector(Vec3* out)
+	{
+		CNode* pNode = GetNodeObject();
+		if (!pNode)
+			return false;
+
+		*out = pNode->GetUpVector();
+
+		return true;
+	}
+
+	float CEntity::GetAngleRadians()
+	{
+		return fmod(atan2(this->mQuat.y, this->mQuat.w), M_PI * 2.f) * 2;
+	}
+
+	//----------------------------------------------------------------------------------------------------
+	//										CZCamera
+	CZCamera* CZCamera::GetDefaultInstance()
+	{
+		CAppCamera* pAppCamera = CAppCamera::GetDefaultInstance();
+		if (!pAppCamera)
+			return nullptr;
+
+		return pAppCamera->GetCameraObject();
+	}
+
+	Vec3 CZCamera::GetOrigin() { return this->mMatrix.Translation(); }
+
+	bool CZCamera::WorldToScreen(const Vec3& worldOrigin, const Vec2& szScreen, Vec2* screen2D)
+	{
+		//	const Mat4x4& mtxWorldToClip = this->mtxViewToClip * this->mtxWorldToView;	//	Model View Projection
+		//	Vec4 clipSpaceOrigin = this->mtxWorldToClip * Vec4(worldOrigin.x, worldOrigin.y, worldOrigin.z, 1.f);
+		//	if (clipSpaceOrigin.w <= 0.1f)
+		//		return false; // behind the camera
+		//	
+		//	Vec4 ndc4 = clipSpaceOrigin / clipSpaceOrigin.w; // Normalize Device Coordinates (NDC)
+		//	Vec4 screen = this->mtxViewToScreen * ndc4; // Convert to screen coordinates
+		//	screen.x = (ndc4.x + 1.0f) * 0.5f * szScreen.x;
+		//	screen.y = (1.0f - ndc4.y) * 0.5f * szScreen.y;
+		//	
+		//	*screen2D = { screen.x, screen.y };
+		//	
+		//	return true;
+
+		static float fov{ 60.f };
+
+		//  get camera view matrix
+
+		Mat4x4 mtxModel = this->mMatrix;
+
+		Vec3 cam_pos = mtxModel.Translation();
+		Vec3 cam_look = Vec3(-mtxModel.m[2][0], -mtxModel.m[2][1], -mtxModel.m[2][2]);
+		Vec3 cam_right = Vec3(mtxModel.m[0][0], mtxModel.m[0][1], mtxModel.m[0][2]);
+		Vec3 cam_up = Vec3(mtxModel.m[1][0], mtxModel.m[1][1], mtxModel.m[1][2]);
+
+		//  get direction or heading
+		Vec3 heading = worldOrigin - cam_pos;
+		float camX = heading.dot(cam_right);
+		float camY = heading.dot(cam_up);
+		float camZ = heading.dot(cam_look);
+
+		//  check if object is behind the camera
+		if (camZ <= 0.f)
+			return false;
+
+		//  apply perspective projection
+		float aspect = szScreen.x / szScreen.y;
+		float fov_radians = tan(fov * 0.5f * (M_PI / 180.f)); // Convert fov to radians and compute scaling factor
+
+		float pX = camX / (camZ * fov_radians * aspect);
+		float pY = camY / (camZ * fov_radians);
+
+		Vec2 res =
+		{
+			(pX + 1.0f) * 0.5f * szScreen.x,
+			(1.0f - pY) * 0.5f * szScreen.y // Invert Y because screen coordinates are top-down
+		};
+
+		if (res.x <= 0.f || res.y <= 0.0f)
+			return false;
+
+		if (res.x > szScreen.x || res.y > szScreen.y)
+			return false;
+
+		*screen2D = res;
+
+		return true;
+	}
+
+
+	//----------------------------------------------------------------------------------------------------
+	//										CZBodyPart
+	Vec3 CZBodyPart::GetOrigin() const { return this->mOrigin; }
+	CNode* CZBodyPart::GetNode() { return (CNode*)PS2Memory::GetEEAddr(this->pNode); }
+	CZBodyPart* CZBodyPart::GetParent() { if (!pParent) return nullptr; return (CZBodyPart*)PS2Memory::GetEEAddr(this->pParent); }
+	std::string CZBodyPart::GetName() { CNode* pNode = GetNode(); return pNode == nullptr ? "" : pNode->GetName(); }
+	Vec3 CZBodyPart::GetLocalOrigin() const { return this->mOrigin; }
+	Vec4 CZBodyPart::GetLocalRotation() const { return this->mQuat; }
+
+	bool CZBodyPart::GetLocalTM(Mat4x4* out)
+	{
+		CNode* pNode = GetNode();
+		if (!pNode)
+			return false;
+
+		*out = pNode->GetWorldTM();
+
+		return true;
+	}
+
+	bool CZBodyPart::GetWorldTM(const Mat4x4& model, Mat4x4* out)
+	{
+		/* get body part matrix */
+		Mat4x4 base_matrix;
+		if (!GetLocalTM(&base_matrix))
+			return false;
+
+		if (!this->pParent)
+		{
+			*out = base_matrix * model;
+			return true;
+		}
+
+		/* iterate body part tree */
+		bool bFoundParents{ false };	// flag to check if parent body parts were found
+		CZBodyPart* pBodyPart = this;	// set current body part as current body part
+		do
+		{
+			/* get parent body part */
+			CZBodyPart* pParentBodyPart = pBodyPart->GetParent();
+			if (!pParentBodyPart)
+			{
+				bFoundParents = true;	// no parent found, exit loop
+				break;
+			}
+
+			/* get parent body part matrix */
+			Mat4x4 parentLocalMatrix;
+			if (!pParentBodyPart->GetLocalTM(&parentLocalMatrix))
+			{
+				bFoundParents = true;	// no parent node found, exit loop
+				break;
+			}
+
+			/* set pBodyPart to the parent & apply matrix transformation on the mtx buffer */
+			pBodyPart = pParentBodyPart;	// set parent body part as current body part
+			base_matrix = base_matrix * parentLocalMatrix;	// multiply parent matrix to temporary matrix
+
+		} while (!bFoundParents);
+
+		*out = base_matrix * model;
+
+		return true;
+	}
+
+	//----------------------------------------------------------------------------------------------------
+	//										CZSealBody
+
+	CZSealBody* CZSealBody::GetDefaultInstance()
+	{
+		if (!Offsets::o_LocalSeal)
+			return nullptr;
+
+		return PS2Memory::GetPtrShort<CZSealBody*>(Offsets::o_LocalSeal);
+	}
+
+	bool CZSealBody::IsValidSeal()
+	{
+		if (!this->IsValid())
+			return false;
+
+		return this->vfTable == 0x668B20;
+	}
+
+	float CZSealBody::GetHealth() { return this->mHealth * 100.f; }
+
+	bool CZSealBody::IsAlive() { return this->mHealth > 0.0f; }
+
+	Enums::ESEAL_STANCE CZSealBody::GetStance() { return this->mStance; }
+
+	bool CZSealBody::GetBoneByIndex(const int& boneIndex, CZBodyPart** out)
+	{
+		if (!this->IsValidSeal())
+			return false;	// invalid seal body instance
+
+		if (boneIndex < 0 || boneIndex >= 0x20)
+			return false;	// invalid index
+
+		i32_t boneOffset = this->mSkeleton[boneIndex];	// get bone offset from skeleton array
+		if (boneOffset <= 0)
+			return false;	// invalid bone pointer
+
+		*out = (CZBodyPart*)PS2Memory::GetEEAddr(boneOffset);	// get bone index from skeleton array
+
+		return true;
+	}
+
+	bool CZSealBody::GetBoneWorldTM(const int& boneIndex, Mat4x4* out)
+	{
+
+		/* get bone body part reference */
+		CZBodyPart* pBodyPart = nullptr;
+		if (!GetBoneByIndex(boneIndex, &pBodyPart))
+			return false;
+
+		/* return the results */
+		return pBodyPart->GetWorldTM(this->mMatrix, out);
+
+
+		/* declare math constants */
+		const Mat4x4& modelWorldMatrix = this->mMatrix;
+		const Vec3& modelWorldOrigin = modelWorldMatrix.Translation(); //	 Vec3(modelWorldMatrix.m[3][0], modelWorldMatrix.m[3][1], modelWorldMatrix.m[3][2]);
+
+		//	/* get bone body part reference */
+		//	CZBodyPart* pBodyPart = nullptr;
+		//	if (!GetBoneByIndex(boneIndex, &pBodyPart))
+		//		return false;
+
+		/* get body part node */
+		CNode* pBodyPartNode = pBodyPart->GetNode();
+		if (!pBodyPartNode)
+			return false;	// invalid body part node
+
+		/* get bone world matrix */
+		//	Mat4x4 bodyPartLocalMatrix = pBodyPartNode->GetWorldTM();
+		//	Vec3 bodyPartLocalOrigin = pBodyPartNode->GetWorldPos();
+
+
+		Vec3 tempOrigin; // create temporary origin vector to store result
+		Mat4x4 tempMatrix; // create temporary matrix to store result
+		bool bFoundParents{ false };
+		do
+		{
+			CZBodyPart* pParentBodyPart = pBodyPart->GetParent();
+			if (!pParentBodyPart)
+			{
+				bFoundParents = true;	// no parent found, exit loop
+				break;
+			}
+			/* get parent body part node */
+			CNode* pParentBodyPartNode = pParentBodyPart->GetNode();
+			if (!pParentBodyPartNode)
+			{
+				bFoundParents = true;	// no parent node found, exit loop
+				break;
+			}
+
+			pBodyPart = pParentBodyPart;	// set parent body part as current body part
+
+			/* get parent bone world matrix */
+			Mat4x4 parentLocalMatrix = pParentBodyPartNode->GetWorldTM();
+			Vec3 parentLocalOrigin = pParentBodyPartNode->GetWorldPos();
+
+			tempOrigin += parentLocalOrigin;	// add parent origin to temporary origin
+			tempMatrix = tempMatrix * parentLocalMatrix;	// multiply parent matrix to temporary matrix
+
+		} while (!bFoundParents);
+
+		*out = tempMatrix * modelWorldMatrix;
+
+		return true;
+	}
+
+	bool CZSealBody::GetBoneLocationByIndex(const int& boneIndex, Vec3& outPosition)
+	{
+		Mat4x4 boneWorldMX;
+		if (!GetBoneWorldTM(boneIndex, &boneWorldMX))
+			return false;	//	cannot get bone world matrix
+
+		outPosition = boneWorldMX.Translation();	// get bone world position from matrix translation
+
+		return true;
+	}
+
+	void CZSealBody::SetAimPoint(const Vec3& newAim)
+	{
+		this->mAimWorldPos = newAim;
+		this->mAimPoint = newAim;
+		this->mPrevAimPoint = newAim;
+		this->mReticlePt = newAim;
+		this->mPrevReticlePt = newAim;
+	}
+
+	bool CZSealBody::SetAimTarget(CZSealBody* pTarget, bool bVisible, const Enums::ESEALBONES_INDEX& bone)
+	{
+		if (!this->IsValid() || !this->IsAlive() || !pTarget || !pTarget->IsValid() || !pTarget->IsAlive())
+			return false;
+
+		Vec3 targetOrigin;
+		if (!pTarget->GetBoneLocationByIndex(bone, targetOrigin))
+			return false;
+
+		/* get direction */
+		Vec3 dir = targetOrigin - this->mAimWorldPos;
+
+		return SetAimTarget(targetOrigin);
+	}
+
+	bool CZSealBody::SetAimTarget(const Vec3& location) { SetAimPoint(location); return true; }
+
+	CTarget* CZSealBody::GetTargetEntity(CZSealBody* pTarget)
+	{
+		if (!this || !this->IsValid() || !this->IsAlive())
+			return nullptr;
+
+		std::vector<CTarget*> targets;
+		if (!this->GetTargets(targets))
+			return nullptr;
+
+		for (const auto& target : targets)
+		{
+			CEntity* pEntity = reinterpret_cast<CEntity*>(PS2Memory::GetEEAddr(target->pEntity));
+			if (!pEntity || !pTarget || !pTarget->IsValid())
+				continue;
+
+			if (pEntity == (CEntity*)pTarget)
+				return target;
+		}
+
+		return nullptr;
+	}
+
+#pragma endregion
+
+	//----------------------------------------------------------------------------------------------------
+	//										CCAMERA
+	//-----------------------------------------------------------------------------------
+
+
+	//----------------------------------------------------------------------------------------------------
+	//										CZSEALOBJECT
+	//-----------------------------------------------------------------------------------
+
+	//---------------------------------------------------------------------------------------------------
+	CZSealObject* CZSealObject::GetDefaultInstance()
+	{
+		auto pSeal = CZSeal::GetDefaultInstance();
+		if (!pSeal)
+			return nullptr;
+
+		return pSeal->GetSealObject();
+	}
+
+	//---------------------------------------------------------------------------------------------------
+	void CZSealObject::SetPosition(Vec3 pos) { this->m_absPosition = pos; }
+	
+	//----------------------------------------------------------------------------------------------------
+	//										CZSEAL
+	//-----------------------------------------------------------------------------------
+
+	//---------------------------------------------------------------------------------------------------
+	CZSeal* CZSeal::GetDefaultInstance()
+	{
+		if (!Offsets::o_LocalSeal)
+			return nullptr;
+
+		return PS2Memory::GetPtrShort<CZSeal*>(Offsets::o_LocalSeal);
+	}
+
+	//---------------------------------------------------------------------------------------------------
+	bool CZSeal::IsValid()
+	{
+		return (this->m_pName > 0 && this->m_pSealObj > 0 && this->m_teamID > ETeam::NONE);
+	}
+
+	//---------------------------------------------------------------------------------------------------
+	CZSealObject* CZSeal::GetSealObject()
+	{
+		return reinterpret_cast<CZSealObject*>(PS2Memory::GetEEAddr(this->m_pSealObj));
+	}
+
+	//---------------------------------------------------------------------------------------------------
+	Vec3 CZSeal::GetPosition() { return this->m_relativeLocation; }
+
+	//---------------------------------------------------------------------------------------------------
+	Vec2 CZSeal::GetRotation() { return Vec2(this->rotation.x, this->rotation.z); }
+
+	//---------------------------------------------------------------------------------------------------
+	std::string CZSeal::GetName() 
+	{
+		if (!this->IsValid())
+			return "";
+
+		return (char*)PS2Memory::GetEEAddr(this->m_pName);
+	}
+
+	//---------------------------------------------------------------------------------------------------
+	ETeam CZSeal::GetTeam() { return this->m_teamID; }
+
+	//---------------------------------------------------------------------------------------------------
+	float CZSeal::GetHealth() { return this->m_health * 100.f; }
+
+	//---------------------------------------------------------------------------------------------------
+	bool CZSeal::IsAlive() { return this->m_health > 0.0f; }
+
+	//---------------------------------------------------------------------------------------------------
+	void CZSeal::ChangeTeams(ETeam id) { this->m_teamID = id; }
+
+	//----------------------------------------------------------------------------------------------------
+	//										CZWEAPON
+	//-----------------------------------------------------------------------------------
+
+	//---------------------------------------------------------------------------------------------------
+	Vec3 CZWeapon::GetBulletPos()
+	{
+		return Vec3(0, 0, 0);
+	}
+
+	//---------------------------------------------------------------------------------------------------
+	void CZWeapon::SetBulletPos(Vec3 Pos)
+	{
+
+	}
+
+	//----------------------------------------------------------------------------------------------------
+	//										CZKIT
+	//-----------------------------------------------------------------------------------
+
+	//---------------------------------------------------------------------------------------------------
+	void CZKit::GiveWeapon(EWeapon w, EWeaponSlot s, EAmmoType a, EFireType f)
+	{
+		switch (s)
+		{
+			case EWeaponSlot::Primary:
+			{
+				this->Primary = w;
+				this->PrimaryAmmoType = a;
+				this->PrimaryFireType = f;
+				break;
+			}
+
+			case EWeaponSlot::Secondary:
+			{
+				this->Secondary = w;
+				this->SecondaryAmmoType = a;
+				this->SecondaryFireType = f;
+				break;
+			}
+			
+			case EWeaponSlot::EqSlot1:
+			{
+				this->Eq1Ammo = w;
+				this->Eq1AmmoType = a;
+				break;
+			}
+			
+			case EWeaponSlot::EqSlot2:
+			{
+				this->Eq2Ammo = w;
+				this->Eq2AmmoType = a;
+				break;
+			}
+			
+			case EWeaponSlot::EqSlot3:
+			{
+				this->Eq3Ammo = w;
+				this->Eq3AmmoType = a;
+				break;
+			}
+		}
+	}
+
+	//---------------------------------------------------------------------------------------------------
+	void CZKit::GiveAmmo(EWeaponSlot slot, EAmmoType type, __int32 count)
+	{
+
+		switch (slot)
+		{
+			case EWeaponSlot::Primary: 
+			{
+				this->PrimaryAmmoType = type;
+				
+				for (int i = 0; i < 10; i++)
+					this->PrimaryAmmo[i] = count;
+
+				break;
+			}
+			case EWeaponSlot::Secondary:
+			{
+				this->SecondaryAmmoType = type;
+
+				for (int i = 0; i < 10; i++)
+					this->SecondaryAmmo[i] = count;
+
+				break;
+			}
+			case EWeaponSlot::EqSlot1:
+			{
+				this->SecondaryAmmoType = type;
+				this->Eq1Ammo = type;
+
+				break;
+			}
+			case EWeaponSlot::EqSlot2:
+			{
+				this->PrimaryAmmoType = type;
+				this->Eq2Ammo = type;
+
+				break;
+			}
+			case EWeaponSlot::EqSlot3:
+			{
+				this->PrimaryAmmoType = type;
+				this->Eq3Ammo = type;
+
+				break;
+			}
+		}
+	}
+
+	//---------------------------------------------------------------------------------------------------
+	std::string CZKit::ExportLoadoutInfo()
+	{
+		char data[MAX_PATH];
+		const char* data_ = "[LoadoutInfo: %s]\nPrimary: 0x%08X\nPrimary Ammo: 0x%08X\nPrimary Mag 0x%08X\nSecondary: 0x%08X\nSecondary Ammo: 0x%08X\nSecondary Mag1: 0x%08X\nEqSlot1: 0x%08X\nEqSlot1 Ammo Type: 0x%08X\nEq Slot1 Mag: 0x%08X\nEqSlot2: 0x%08X\nEqSlot2 Ammo Type: 0x%08X\nEq Slot2 Mag: 0x%08X\nEqSlot3: 0x%08X\nEqSlot3 Ammo Type: 0x%08X\nEq Slot3 Mag: 0x%08X\n\n";
+		sprintf_s(data, data_,
+			this->Primary,
+			this->PrimaryAmmoType,
+			this->PrimaryAmmo[0],
+			this->Secondary,
+			this->SecondaryAmmoType,
+			this->SecondaryAmmo[0],
+			this->EqSlot1,
+			this->Eq1AmmoType,
+			this->Eq1Ammo,
+			this->EqSlot2,
+			this->Eq2AmmoType,
+			this->Eq2Ammo,
+			this->EqSlot3,
+			this->Eq3AmmoType,
+			this->Eq3Ammo
+		);
+		return data;
+	}
+	
+
+	//----------------------------------------------------------------------------------------------------
+	//										CZMATCHDATA
+	//-----------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------
+	void CZMatchData::ForceStartMatch(bool bActive)
+	{
+		unsigned int patch = 0x0;
+		auto addr = PS2Memory::GetEEAddr(Patches::ForceMatch.dst);
+		std::pair<unsigned int, unsigned int> pairs = { 0x0027E280, 0x0027DD00 };
+		switch (bActive)
+		{
+			case TRUE:	patch = Patches::ForceMatch.patch; break;
+			case FALSE: patch = Patches::ForceMatch.original; break;
+		}
+		PS2Memory::WriteLong<uint32_t>(addr, patch);
+	}
+	
+	//---------------------------------------------------------------------------------------------------
+	void CZMatchData::SetEndlessMatch(bool bActive)
+	{
+		unsigned int patch = 0x0;
+		auto addr = PS2Memory::GetEEAddr(Patches::EndlessMatch.dst);
+		std::pair<unsigned int, unsigned int> pairs = { 0xFFFFFFFF, 0x00124F80 };
+		switch (bActive)
+		{
+			case TRUE:	patch = Patches::EndlessMatch.patch; break;
+			case FALSE: patch = Patches::EndlessMatch.original; break;
+		}
+		PS2Memory::WriteLong<uint32_t>(addr, patch);
+	}
+
+	bool CZMatchData::GetEntities(std::vector<CZSealBody*>* entities)
+	{
+		std::vector<CZSealBody*> result{};
+
+		const auto arr = PS2Memory::ReadEE<ZArray<CZSealBody*>>(Offsets::o_pEntityArray).Data();
+
+		for (auto ent : arr)
+		{
+			if (!ent->IsValid())
+				continue;
+
+			//	CNode* pNode = ent->GetSealObject();
+			//	if (!pNode)
+			//		continue;	//	invalid node, skip
+			//	
+			//	if (!pNode->m_hasVisuals)
+			//		continue;
+
+			result.push_back(ent);
+		}
+
+		*entities = result;
+
+		return result.size() > 0;
+	}
+
+	//---------------------------------------------------------------------------------------------------
+	void CZMatchData::EndCurrentRound()
+	{
+		auto addr = PS2Memory::GetEEAddr(Offsets::MatchTimer);
+		if (addr != NULL)
+			PS2Memory::WriteLong<uint32_t>(addr, NULL);
+	}
+
+	//---------------------------------------------------------------------------------------------------
+	std::vector<CZSeal*> CZMatchData::GetPlayers()
+	{
+		int count = NULL;
+		std::vector<CZSeal*> ents{};
+
+		//   Grab the first entityObjectPointer in the array
+		auto entArray = PS2Memory::GetEEAddr(Offsets::p_EntityArray);
+		if (entArray == NULL) 
+			return ents;
+
+		//   Store base address for later because the entity array loops back to the beginning
+		auto baseEntity = entArray;
+
+		size_t maxSize = 0x64;
+		for (int i = 0; i <= maxSize; i++)
+		{
+			//	Cast entity object to CPlayer Class
+			CZSeal* ent = (CZSeal*)((*(int32_t*)(entArray + 0x8)) + PS2Memory::GetEEBase());
+			if (ent == NULL)
+				break;
+
+			if (!ent->IsValid())
+			{
+				// Get next entity in the array
+				entArray = *(int32_t*)entArray + PS2Memory::GetEEBase();
+				continue;
+			}
+
+			//	Push CPlayer Object into the vector array
+			ents.push_back(ent);
+
+			// Get next entity in the array
+			entArray = *(int32_t*)entArray + PS2Memory::GetEEBase();
+
+			if (entArray == baseEntity)
+				break;
+		}
+
+		//	return array of players
+		return ents;
+	}
+
+
+	//---------------------------------------------------------------------------------------------------
+	bool CZMatchData::GetPlayers(std::vector<CZSeal*>* p)
+	{
+		std::vector<CZSeal*> result{};
+
+		const auto arr = PS2Memory::ReadEE<ZArray<CZSeal*>>(Offsets::p_EntityArray).Data();
+
+		for (auto ent : arr)
+		{
+			if (!ent->IsValid())
+				continue;
+
+			result.push_back(ent);
+		}
+
+		*p = result;
+
+		return result.size() > 0;
+	}
+
+	//---------------------------------------------------------------------------------------------------
+	std::vector<CZSeal*> CZMatchData::GetAlivePlayers()
+	{
+		auto _players = GetPlayers();
+
+		std::vector<CZSeal*> _result;
+
+		for (auto player : _players)
+		{
+			if (!player->IsAlive())
+				continue;
+
+			_result.push_back(player);
+		}
+		
+		return _result;
+	}
+
+	//---------------------------------------------------------------------------------------------------
+	std::string CZMatchData::LogData()
+	{
+		// Data
+		// - Player Count
+		// - Map Name
+		// - Current Round
+		// - Match Timer
+		return "";
+	}
+
+
+}
+#pragma pack(pop)

--- a/modules/SOCOM 2 U.S Navy Seals/SOCOM2_package.h
+++ b/modules/SOCOM 2 U.S Navy Seals/SOCOM2_package.h
@@ -1,0 +1,182 @@
+#pragma once
+#include <string>
+
+/**
+ * Name: SOCOM 2
+ * Platform: PlayStation 2
+ * PCSX2 Version: 1.7 beta
+ * Author: NightFyre
+*/
+
+#pragma pack(push, 0x01)
+namespace PlayStation2
+{
+	namespace SOCOM2
+	{
+		// --------------------------------------------------
+		// # Forwards
+		// --------------------------------------------------
+		typedef unsigned __int32  i32_t;
+
+		/* WEAPONS */
+#define WEAPON_MODEL_18 0xC66FE0
+#define WEAPON_MARK_23 0xC67270
+#define WEAPON_F57 0xC67500
+#define WEAPON_DE50 0xC67790
+#define WEAPON_M9 0xC67A20
+#define WEAPON_226 0xC67CD0
+#define WEAPON_MARK_23_SD  0xC67F60
+#define WEAPON_9MM_PISTOL  0xC681F0
+#define WEAPON_M11 0xC68480
+#define WEAPON_SP10 0xC68710
+#define WEAPON_LASER_DESIGNATOR 0xC689A0
+#define WEAPON_TA_SHOTGUN 0xC68C50
+#define WEAPON_MK3_A2_SHOTGUN 0xC68EE0
+#define WEAPON_REMINGTON_870 0xC69170
+#define WEAPON_M16A2 0xC69400
+#define WEAPON_M16A2_M203 0xC69690
+#define WEAPON_M4A1 0xC69920
+#define WEAPON_M4A1_SD 0xC69BB0
+#define WEAPON_M4A1_M203 0xC69E40
+#define WEAPON_552 0xC6A0D0
+#define WEAPON_552_SD 0xC6A360
+#define WEAPON_AK47 0xC6A5F0
+#define WEAPON_AKS74 0xC6A880
+#define WEAPON_M14 0xC6AB10
+#define WEAPON_OICW 0xC6ADA0
+#define WEAPON_IW_80_A2 0xC6B030
+#define WEAPON_AK105 0xC6B2C0
+#define WEAPON_RA14 0xC6B550
+#define WEAPON_M60E3 0xC6B7E0
+#define WEAPON_M63A 0xC6BA70
+#define WEAPON_PKM 0xC6BD00
+#define WEAPON_HK5 0xC6BF90
+#define WEAPON_HK5_SD 0xC6C220
+#define WEAPON_F90 0xC6C4B0
+#define WEAPON_9MM_SUB 0xC6C740
+#define WEAPON_STG_77 0xC6C9D0
+#define WEAPON_HK5K 0xC6CC60
+#define WEAPON_M82A1A 0xC6CEF0
+#define WEAPON_M40A1 0xC6D180
+#define WEAPON_M87ELR 0xC6D410
+#define WEAPON_SR25_SD 0xC6D6A0
+#define WEAPON_SR25 0xC6D930
+#define WEAPON_SASR 0xC6DBC0
+#define WEAPON_DETONATOR 0xC6DE50
+#define WEAPON_EMPTY 0xC6E0E0
+#define WEAPON_NONE 0xC6E370
+#define WEAPON_THERMAL SCOPE 0xC6E600
+#define WEAPON_BINOCULARS 0xC6E890
+#define WEAPON_M67 0xC6EB20
+#define WEAPON_HE 0xC6EDB0
+#define WEAPON_SMOKE 0xC6F040
+#define WEAPON_CHEM_LIGHT 0xC6F2D0
+#define WEAPON_RED_SMOKE  0xC6F560
+#define WEAPON_FLASHBANG 0xC6F7F0
+#define WEAPON_SATCHEL 0xC6FAA0
+#define WEAPON_CLAYMORE 0xC6FD30
+#define WEAPON_PMN_MINE 0xC6FFC0
+#define WEAPON_C4 0xC70250
+#define WEAPON_MPBOMB 0xC704E0
+#define WEAPON_M203 0xC70770
+#define WEAPON_M203_HE 0xC70A00
+#define WEAPON_M203_FRAG 0xC70C90
+#define WEAPON_M203_SMOKE 0xC70F20
+#define WEAPON_OICW_HE 0xC711B0
+#define WEAPON_OICW_FRAG 0xC71440
+#define WEAPON_OICW_SMOKE 0xC716D0
+#define WEAPON_MGL 0xC71960
+#define WEAPON_M79 0xC71BF0
+#define WEAPON_M79_HE 0xC71E80
+#define WEAPON_M79_FRAG 0xC72110
+#define WEAPON_M79_SMOKE 0xC723A0
+#define WEAPON_ARTILLERY SHELL 0xC72630
+#define WEAPON_AT4 0xC728C0
+#define WEAPON_AT4_HEAT 0xC72B50
+#define WEAPON_RPG7 0xC72DE0
+#define WEAPON_RPG_ROUND 0xC73070
+#define WEAPON_BACKBLAST 0xC73300
+#define WEAPON_KEVLAR_ARMOR 0xC73590
+#define WEAPON_KEVLAR_ARMOR_INSERT 0xC73820
+#define WEAPON_2X_AMMO 0xC73AF0
+#define WEAPON_ATG_MISSILE 0xC73D80
+#define WEAPON_EXPLOSION 0xC74010
+#define WEAPON_SATCHEL_EXPLOSION 0xC742A0
+#define WEAPON_TURRET_RMG 0xC74530
+#define WEAPON_TURRET_30MM_MGL 0xC747C0
+#define WEAPON_TURRET_LMG 0xC74A50
+
+		/* AMMO TYPES */
+#define AMMO_9x19P 0xC663B0
+#define AMMO_9x21mm 0xC66400
+#define AMMO_57x28mm 0xC66450
+#define AMMO_LONG_RIFLE 0xC664A0
+#define AMMO_45ACP 0xC664F0
+#define AMMO_50AE 0xC66540
+#define AMMO_545x39mm_SOVIET 0xC66590
+#define AMMO_556x45mm 0xC665E0
+#define AMMO_762x51mm 0xC66630
+#define AMMO_762x39mm_M1943 0xC66680
+#define AMMO_762x54R 0xC666D0
+#define AMMO_50BMG 0xC66720
+#define AMMO_12GUAGE 0xC66770
+#define AMMO_M67 0xC667C0
+#define AMMO_HE 0xC66810
+#define AMMO_SMOKE 0xC66860
+#define AMMO_RED_SMOKE 0xC668B0
+#define AMMO_CHEM_LIGHT 0xC66900
+#define AMMO_FLASHBANG 0xC66950
+#define AMMO_SATCHEL 0xC669A0
+#define AMMO_CLAYMORE 0xC669F0
+#define AMMO_PMN_MINE 0xC66A40
+#define AMMO_C4 0xC66A90
+#define AMMO_MPBOMB 0xC66AE0
+#define AMMO_M203_HE 0xC66B30
+#define AMMO_M203_FRAG 0xC66B80
+#define AMMO_M203_SMOKE 0xC66BD0
+#define AMMO_OICW_HE 0xC66C20
+#define AMMO_OICW_FRAG 0xC66C70
+#define AMMO_OICW_SMOKE 0xC66CC0
+#define AMMO_M79_HE 0xC66D10
+#define AMMO_M79_FRAG 0xC66D60
+#define AMMO_M79_SMOKE 0xC66DB0
+#define AMMO_AT4_HEAT 0xC66E00
+#define AMMO_BACKBLAST 0xC66E50
+#define AMMO_ARTILLERY_SHELL 0xC66EA0
+#define AMMO_RPG 0xC66EF0
+#define AMMO_MISSILE 0xC66F40
+#define AMMO_EXPLOSIVE_STUFF 0xC66F90
+
+		// --------------------------------------------------
+		// # Global functions
+		// --------------------------------------------------
+
+		i32_t GetWeaponByIndex(int index);
+		i32_t GetAmmoTypeByIndex(int index);
+		i32_t GetTeamIDByIndex(int index);
+
+		std::string GetWeaponName(i32_t oWeapon);
+		std::string GetAmmoTypeName(i32_t oAmmo);
+		std::string GetFireTypeName(int ftIndex);
+		std::string GetTeamNameByID(int teamid);
+
+		//	bool GetBoneNameByIndex(i32_t pCZSealBody, int index, std::string& outResult);
+		//	bool GetBoneTransformByIndex(i32_t pCZSealBody, int index, Mat4x4& outResult);
+
+		// --------------------------------------------------
+		namespace Dumper
+		{
+			void DumpWeaponStats();
+			void DumpAmmoStats();
+			void DumpBoneNames();
+			void DumpBoneHierarchy();
+		}
+	}
+
+}
+#pragma pack(pop)
+
+#include <PCSX2/CDK.h>
+#include "SOCOM2_Structs.h"
+#include "SOCOM2_Classes.h"
+#include "data/names.h"


### PR DESCRIPTION
This pull request introduces the initial implementation of support for SOCOM 2: U.S. Navy Seals for PlayStation 2. The main changes include the addition of a README file with game metadata and a new header file that defines weapon and ammo constants, type aliases, and global functions relevant to the game.

**SOCOM 2 game metadata and documentation:**

* Added a new `README.md` file for `SOCOM 2: U.S. Navy Seals` containing the game's serial and CRC information.

**SOCOM 2 game definitions and API:**

* Created `SOCOM2_package.h` with type definitions, weapon and ammo constant mappings, and function prototypes for retrieving weapon, ammo, and team information, as well as utility functions for dumping game data. Includes relevant header imports for further development.